### PR TITLE
Feat/swipe to queue patch

### DIFF
--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -436,10 +436,11 @@
         "radiant/swipe/QueueExecutor.smali",
         "radiant/swipe/FavoriteTracksResolver.smali",
         "radiant/swipe/DynamicTrackResolver.smali",
-        "radiant/swipe/MyAlbumsResolver.smali"
+        "radiant/swipe/MyAlbumsResolver.smali",
+        "radiant/swipe/MyPlaylistsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks/albums to add them to the play queue.",
+      "description": "Swipe on tracks/albums/playlists to add them to the play queue.",
       "default": false,
       "advancedOptions": [
         {

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -430,10 +430,16 @@
       ],
       "extensionFiles": [
         "radiant/SwipeToQueue.smali",
-        "radiant/QueueSwipeRemove.smali"
+        "radiant/QueueSwipeRemove.smali",
+        "radiant/swipe/QueueRequest.smali",
+        "radiant/swipe/QueueRowResolver.smali",
+        "radiant/swipe/QueueExecutor.smali",
+        "radiant/swipe/FavoriteTracksResolver.smali",
+        "radiant/swipe/DynamicTrackResolver.smali",
+        "radiant/swipe/MyAlbumsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "description": "Swipe on tracks/albums to add them to the play queue.",
       "default": false,
       "advancedOptions": [
         {

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -458,7 +458,17 @@
         "radiant/swipe/ViewAllTrackQueue.smali",
         "radiant/swipe/ComposeSearchQueueEvent.smali",
         "radiant/swipe/ComposeSearchQueueAction.smali",
-        "radiant/swipe/ComposeSearchQueue.smali"
+        "radiant/swipe/ComposeSearchQueue.smali",
+        "radiant/swipe/FeedResolver.smali",
+        "radiant/swipe/ArtistTrackCreditsQueueEvent.smali",
+        "radiant/swipe/ArtistTrackCreditsQueueAction.smali",
+        "radiant/swipe/ArtistTrackCreditsQueue.smali",
+        "radiant/swipe/DynamicMediaQueueEvent.smali",
+        "radiant/swipe/CompactGridMediaQueueAction.smali",
+        "radiant/swipe/VerticalMediaQueueAction.smali",
+        "radiant/swipe/PublicPlaylistQueueAction.smali",
+        "radiant/swipe/DynamicMediaQueue.smali",
+        "radiant/swipe/SuggestionsResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue",

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -471,25 +471,27 @@
         "radiant/swipe/SuggestionsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks/albums/playlists to add them to the play queue",
+      "description": "Swipe on tracks/albums/playlists to add them to the play queue (and more actions)",
       "default": false,
       "advancedOptions": [
         {
           "type": "choice",
           "key": "left_action",
           "title": "Left Swipe Action",
-          "description": "Choose the action for a left swipe",
           "entries": [
             "Disabled",
             "Play next",
-            "Add to queue"
+            "Add to queue",
+            "Add to playlist"
           ],
           "values": [
             "0x0",
             "0x1",
-            "0x2"
+            "0x2",
+            "0x3"
           ],
           "defaultIndex": 2,
+          "inline": true,
           "distinctFrom": "right_action",
           "token": "RL_SWIPE_TO_QUEUE_LEFT_ACTION"
         },
@@ -497,18 +499,20 @@
           "type": "choice",
           "key": "right_action",
           "title": "Right Swipe Action",
-          "description": "Choose the action for a right swipe",
           "entries": [
             "Disabled",
             "Play next",
-            "Add to queue"
+            "Add to queue",
+            "Add to playlist"
           ],
           "values": [
             "0x0",
             "0x1",
-            "0x2"
+            "0x2",
+            "0x3"
           ],
           "defaultIndex": 0,
+          "inline": true,
           "distinctFrom": "left_action",
           "token": "RL_SWIPE_TO_QUEUE_RIGHT_ACTION"
         },
@@ -516,11 +520,10 @@
           "type": "choice",
           "key": "remove_direction",
           "title": "Remove Track from Queue",
-          "description": "Choose the swipe direction used to remove items from the play queue",
           "entries": [
             "Left swipe",
             "Right swipe",
-            "Both"
+            "Both directions"
           ],
           "values": [
             "0x4",
@@ -528,6 +531,8 @@
             "0xc"
           ],
           "defaultIndex": 0,
+          "forceDropdown": true,
+          "inline": true,
           "token": "RL_SWIPE_TO_QUEUE_REMOVE_DIRECTION"
         },
         {
@@ -543,6 +548,13 @@
           "title": "Play Next Color",
           "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
+        },
+        {
+          "type": "color",
+          "key": "add_to_playlist_color",
+          "title": "Add to Playlist Color",
+          "default": -14408663,
+          "token": "RL_SWIPE_TO_QUEUE_ADD_TO_PLAYLIST_COLOR"
         }
       ]
     },

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -476,26 +476,75 @@
       "advancedOptions": [
         {
           "type": "choice",
-          "key": "swipe_direction",
-          "title": "Swipe Direction",
-          "description": "Choose direction of the swipe gesture",
+          "key": "left_action",
+          "title": "Left Swipe Action",
+          "description": "Choose the action for a left swipe",
           "entries": [
-            "Left",
-            "Right"
+            "Disabled",
+            "Play next",
+            "Add to queue"
+          ],
+          "values": [
+            "0x0",
+            "0x1",
+            "0x2"
+          ],
+          "defaultIndex": 2,
+          "distinctFrom": "right_action",
+          "token": "RL_SWIPE_TO_QUEUE_LEFT_ACTION"
+        },
+        {
+          "type": "choice",
+          "key": "right_action",
+          "title": "Right Swipe Action",
+          "description": "Choose the action for a right swipe",
+          "entries": [
+            "Disabled",
+            "Play next",
+            "Add to queue"
+          ],
+          "values": [
+            "0x0",
+            "0x1",
+            "0x2"
+          ],
+          "defaultIndex": 0,
+          "distinctFrom": "left_action",
+          "token": "RL_SWIPE_TO_QUEUE_RIGHT_ACTION"
+        },
+        {
+          "type": "choice",
+          "key": "remove_direction",
+          "title": "Remove Track from Queue",
+          "description": "Choose the swipe direction used to remove items from the play queue",
+          "entries": [
+            "Left swipe",
+            "Right swipe",
+            "Both"
           ],
           "values": [
             "0x4",
-            "0x8"
+            "0x8",
+            "0xc"
           ],
           "defaultIndex": 0,
-          "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+          "token": "RL_SWIPE_TO_QUEUE_REMOVE_DIRECTION"
         },
         {
           "type": "color",
           "key": "background_color",
-          "title": "Background Color",
+          "title": "Add to Queue Color",
+          "default": -14748953,
+          "defaultLabel": "Cyan",
+          "token": "RL_SWIPE_TO_QUEUE_ADD_COLOR"
+        },
+        {
+          "type": "color",
+          "key": "play_next_color",
+          "title": "Play Next Color",
           "default": -14749031,
-          "token": "RL_SWIPE_TO_QUEUE_COLOR"
+          "defaultLabel": "Green",
+          "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
         }
       ]
     },

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -426,7 +426,8 @@
       "id": "SwipeToQueue",
       "order": 39,
       "fileNames": [
-        "swipe-to-queue.patch"
+        "swipe-to-queue.patch",
+        "swipe-to-queue-compose.patch"
       ],
       "extensionFiles": [
         "radiant/SwipeToQueue.smali",
@@ -442,10 +443,25 @@
         "radiant/swipe/SearchAlbumsResolver.smali",
         "radiant/swipe/SearchPlaylistsResolver.smali",
         "radiant/swipe/PlaylistItemsResolver.smali",
-        "radiant/swipe/UnifiedSearchResolver.smali"
+        "radiant/swipe/UnifiedSearchResolver.smali",
+        "radiant/swipe/ComposeSwipeAction.smali",
+        "radiant/swipe/ComposeSwipeState.smali",
+        "radiant/swipe/ComposeSwipeState$Gesture.smali",
+        "radiant/swipe/ComposeSwipeState$Draw.smali",
+        "radiant/swipe/ComposeSwipeState$ResetAnimator.smali",
+        "radiant/swipe/ComposeTapGuard.smali",
+        "radiant/swipe/AlbumItemQueueAction.smali",
+        "radiant/swipe/DynamicTrackQueueEvent.smali",
+        "radiant/swipe/DynamicTrackQueueAction.smali",
+        "radiant/swipe/DynamicTrackQueue.smali",
+        "radiant/swipe/ViewAllTrackQueueAction.smali",
+        "radiant/swipe/ViewAllTrackQueue.smali",
+        "radiant/swipe/ComposeSearchQueueEvent.smali",
+        "radiant/swipe/ComposeSearchQueueAction.smali",
+        "radiant/swipe/ComposeSearchQueue.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks/albums/playlists to add them to the play queue.",
+      "description": "Swipe on tracks/albums/playlists to add them to the play queue",
       "default": false,
       "advancedOptions": [
         {

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -437,7 +437,8 @@
         "radiant/swipe/FavoriteTracksResolver.smali",
         "radiant/swipe/DynamicTrackResolver.smali",
         "radiant/swipe/MyAlbumsResolver.smali",
-        "radiant/swipe/MyPlaylistsResolver.smali"
+        "radiant/swipe/MyPlaylistsResolver.smali",
+        "radiant/swipe/MyMixesAndRadioResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue.",

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -432,8 +432,26 @@
         "radiant/SwipeToQueue.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe (left only for now) on tracks (in library/my tracks only for now) to add them to the play queue.",
-      "default": false
+      "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "default": false,
+      "advancedOptions": [
+        {
+          "type": "choice",
+          "key": "swipe_direction",
+          "title": "Swipe Direction",
+          "description": "Choose direction of the swipe gesture",
+          "entries": [
+            "Left",
+            "Right"
+          ],
+          "values": [
+            "0x4",
+            "0x8"
+          ],
+          "defaultIndex": 0,
+          "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+        }
+      ]
     },
     {
       "id": "LyricsProgressPill",

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -489,6 +489,13 @@
           ],
           "defaultIndex": 0,
           "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+        },
+        {
+          "type": "color",
+          "key": "background_color",
+          "title": "Background Color",
+          "default": -14749031,
+          "token": "RL_SWIPE_TO_QUEUE_COLOR"
         }
       ]
     },

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -438,7 +438,11 @@
         "radiant/swipe/DynamicTrackResolver.smali",
         "radiant/swipe/MyAlbumsResolver.smali",
         "radiant/swipe/MyPlaylistsResolver.smali",
-        "radiant/swipe/MyMixesAndRadioResolver.smali"
+        "radiant/swipe/MyMixesAndRadioResolver.smali",
+        "radiant/swipe/SearchAlbumsResolver.smali",
+        "radiant/swipe/SearchPlaylistsResolver.smali",
+        "radiant/swipe/PlaylistItemsResolver.smali",
+        "radiant/swipe/UnifiedSearchResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue.",

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -423,6 +423,19 @@
       "default": false
     },
     {
+      "id": "SwipeToQueue",
+      "order": 39,
+      "fileNames": [
+        "swipe-to-queue.patch"
+      ],
+      "extensionFiles": [
+        "radiant/SwipeToQueue.smali"
+      ],
+      "title": "Swipe to Queue",
+      "description": "Swipe (left only for now) on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "default": false
+    },
+    {
       "id": "LyricsProgressPill",
       "order": 40,
       "fileNames": [

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -534,16 +534,14 @@
           "type": "color",
           "key": "background_color",
           "title": "Add to Queue Color",
-          "default": -14748953,
-          "defaultLabel": "Cyan",
+          "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_ADD_COLOR"
         },
         {
           "type": "color",
           "key": "play_next_color",
           "title": "Play Next Color",
-          "default": -14749031,
-          "defaultLabel": "Green",
+          "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
         }
       ]

--- a/Manager/app/src/main/assets/patches-manifest.json
+++ b/Manager/app/src/main/assets/patches-manifest.json
@@ -429,7 +429,8 @@
         "swipe-to-queue.patch"
       ],
       "extensionFiles": [
-        "radiant/SwipeToQueue.smali"
+        "radiant/SwipeToQueue.smali",
+        "radiant/QueueSwipeRemove.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/components/radiant/RadiantInputs.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/components/radiant/RadiantInputs.kt
@@ -3,26 +3,49 @@ package com.meowarex.rlmobile.ui.components.radiant
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.meowarex.rlmobile.R
 import com.meowarex.rlmobile.ui.theme.*
 
 /**
@@ -110,6 +133,151 @@ fun RadiantTextField(
         }
 
         trailing?.invoke()
+    }
+}
+
+/**
+ * Dropdown
+ */
+@Composable
+fun RadiantDropdown(
+    options: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    disabledIndices: Set<Int> = emptySet(),
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val visibilityState = remember { MutableTransitionState(false) }
+    visibilityState.targetState = expanded
+    val transition = rememberTransition(visibilityState, label = "Dropdown")
+    val progress by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 160, easing = FastOutSlowInEasing) },
+        label = "DropdownProgress",
+    ) {
+        if (it) 1f else 0f
+    }
+    val scheme = MaterialTheme.colorScheme
+    val selectedLabel = options.getOrNull(selectedIndex).orEmpty()
+    val shape = if (radiantStyle.native) MaterialTheme.shapes.extraSmall else RoundedCornerShape(16.dp)
+    var anchorWidthPx by remember { mutableIntStateOf(0) }
+    val anchorWidth = with(LocalDensity.current) { anchorWidthPx.toDp() }
+    val positionProvider = MenuDefaults.rememberDropdownMenuPopupPositionProvider(
+        dropdownMenuAnchorPosition = MenuAnchorPosition.Below,
+        offset = DpOffset(0.dp, 6.dp),
+    )
+    Box(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { anchorWidthPx = it.width }
+                .background(scheme.surfaceContainerLowest.copy(alpha = 0.8f), shape)
+                .then(
+                    if (radiantStyle.native) Modifier.border(1.dp, scheme.outline, shape)
+                    else Modifier.border(
+                        RadiantDesign.Hairline,
+                        hairlineBrush(scheme.onSurface, RadiantDesign.BORDER_ALPHA * 1.5f),
+                        shape,
+                    )
+                )
+                .clip(shape)
+                .clickable(enabled = enabled, role = Role.Button) { expanded = !expanded }
+                .alpha(if (enabled) 1f else 0.45f)
+                .heightIn(min = 52.dp)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        ) {
+            Text(
+                text = selectedLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = scheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_down_small),
+                contentDescription = null,
+                modifier = Modifier.rotate(180f * progress),
+            )
+        }
+
+        if (
+            anchorWidthPx > 0 &&
+            (visibilityState.currentState || visibilityState.targetState || transition.isRunning)
+        ) {
+            Popup(
+                popupPositionProvider = positionProvider,
+                onDismissRequest = { expanded = false },
+                properties = PopupProperties(focusable = true),
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .width(anchorWidth)
+                        .graphicsLayer {
+                            alpha = progress
+                            scaleX = 0.92f + 0.08f * progress
+                            scaleY = 0.92f + 0.08f * progress
+                            transformOrigin = positionProvider.transformOrigin
+                        },
+                    shape = shape,
+                    color = scheme.surfaceContainer,
+                    tonalElevation = 0.dp,
+                    shadowElevation = 8.dp,
+                    border = BorderStroke(
+                        RadiantDesign.Hairline,
+                        scheme.onSurface.copy(alpha = RadiantDesign.BORDER_ALPHA * 2f),
+                    ),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .heightIn(max = 320.dp)
+                            .verticalScroll(rememberScrollState())
+                            .padding(vertical = 6.dp),
+                    ) {
+                        options.forEachIndexed { index, option ->
+                            val selected = index == selectedIndex
+                            val itemEnabled = enabled && index !in disabledIndices
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        text = option,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                },
+                                trailingIcon = {
+                                    RadiantRadio(
+                                        selected = selected,
+                                        onClick = null,
+                                        enabled = itemEnabled,
+                                    )
+                                },
+                                enabled = itemEnabled,
+                                onClick = {
+                                    onSelect(index)
+                                    expanded = false
+                                },
+                                modifier = Modifier
+                                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .semantics {
+                                        this.selected = selected
+                                        role = Role.RadioButton
+                                    }
+                                    .then(
+                                        if (selected) Modifier.background(scheme.primary.copy(alpha = 0.1f))
+                                        else Modifier
+                                    ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/components/radiant/RadiantInputs.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/components/radiant/RadiantInputs.kt
@@ -161,6 +161,7 @@ fun RadiantSegmented(
     onSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    disabledIndices: Set<Int> = emptySet(),
 ) {
     if (radiantStyle.native) {
         SingleChoiceSegmentedButtonRow(modifier = modifier.fillMaxWidth()) {
@@ -168,7 +169,7 @@ fun RadiantSegmented(
                 SegmentedButton(
                     selected = index == selectedIndex,
                     onClick = { onSelect(index) },
-                    enabled = enabled,
+                    enabled = enabled && index !in disabledIndices,
                     shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
                     icon = {},
                     label = { Text(text = label, maxLines = 1) },
@@ -196,6 +197,7 @@ fun RadiantSegmented(
     ) {
         options.forEachIndexed { index, label ->
             val selected = index == selectedIndex
+            val segmentEnabled = enabled && index !in disabledIndices
             val pillShape = RoundedCornerShape(13.dp)
             val alpha by animateFloatAsState(
                 targetValue = if (selected) 1f else 0f,
@@ -218,7 +220,7 @@ fun RadiantSegmented(
                         } else Modifier
                     )
                     .clickable(
-                        enabled = enabled,
+                        enabled = segmentEnabled,
                         role = Role.RadioButton,
                         onClick = { onSelect(index) },
                     ),
@@ -226,7 +228,11 @@ fun RadiantSegmented(
                 Text(
                     text = label,
                     style = MaterialTheme.typography.labelLarge,
-                    color = if (selected) scheme.onPrimary else scheme.onSurfaceVariant,
+                    color = when {
+                        selected -> scheme.onPrimary
+                        segmentEnabled -> scheme.onSurfaceVariant
+                        else -> scheme.onSurface.copy(alpha = 0.38f)
+                    },
                     maxLines = 1,
                 )
             }

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -166,6 +166,11 @@ fun PatchAdvancedOptionsSheet(
                                                     title = choice.title,
                                                     entries = choice.entries,
                                                     selectedIndex = state.choice(patch, choice),
+                                                    forceDropdown = choice.forceDropdown,
+                                                    disabledIndices = patch.conflictingChoices(choice)
+                                                        .map { state.choice(patch, it) }
+                                                        .filter { it != 0 }
+                                                        .toSet(),
                                                     onSelect = { state.setChoice(patch, choice, it) },
                                                 )
                                             }
@@ -205,6 +210,11 @@ fun PatchAdvancedOptionsSheet(
                                 title = option.title,
                                 entries = option.entries,
                                 selectedIndex = state.choice(patch, option),
+                                forceDropdown = option.forceDropdown,
+                                disabledIndices = patch.conflictingChoices(option)
+                                    .map { state.choice(patch, it) }
+                                    .filter { it != 0 }
+                                    .toSet(),
                                 onSelect = { state.setChoice(patch, option, it) },
                             )
                         }
@@ -213,6 +223,7 @@ fun PatchAdvancedOptionsSheet(
                         title = option.title,
                         color = state.color(patch, option),
                         defaultColor = option.default,
+                        manifestDefaultLabel = option.defaultLabel,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -382,6 +393,8 @@ private fun ChoiceOptionRow(
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     title: String = "",
+    forceDropdown: Boolean = false,
+    disabledIndices: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -397,7 +410,7 @@ private fun ChoiceOptionRow(
                 textAlign = TextAlign.Center,
             )
         }
-        if (entries.size > 3) {
+        if (forceDropdown || entries.size > 3) {
             var expanded by rememberSaveable { mutableStateOf(false) }
             val selectedLabel = entries.getOrNull(selectedIndex).orEmpty()
 
@@ -420,6 +433,7 @@ private fun ChoiceOptionRow(
                     entries.forEachIndexed { index, entry ->
                         DropdownMenuItem(
                             text = { Text(entry) },
+                            enabled = index !in disabledIndices,
                             onClick = {
                                 onSelect(index)
                                 expanded = false
@@ -435,6 +449,7 @@ private fun ChoiceOptionRow(
                 SegmentedButton(
                     selected = index == selectedIndex,
                     onClick = { onSelect(index) },
+                    enabled = index !in disabledIndices,
                     shape = SegmentedButtonDefaults.itemShape(index = index, count = entries.size),
                     icon = {},
                     label = {
@@ -457,17 +472,16 @@ private fun ColorOptionRow(
     title: String,
     color: Int,
     defaultColor: Int,
+    manifestDefaultLabel: String?,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
     val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
     val opaqueDefault = defaultColor.withOpaqueAlpha()
-    val defaultLabel = if (opaqueDefault == TIDAL_GREEN) {
+    val defaultLabel = manifestDefaultLabel ?: if (opaqueDefault == TIDAL_GREEN) {
         stringResource(R.string.patch_color_green)
-    } else {
-        stringResource(R.string.patch_waze_color_waze_default)
-    }
+    } else stringResource(R.string.patch_waze_color_waze_default)
     val presets = listOf(
         defaultLabel,
         stringResource(R.string.patch_waze_color_tidal_cyan),

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -212,6 +212,7 @@ fun PatchAdvancedOptionsSheet(
                     is OptionSpec.Color -> ColorOptionRow(
                         title = option.title,
                         color = state.color(patch, option),
+                        defaultColor = option.default,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -455,17 +456,24 @@ private fun ChoiceOptionRow(
 private fun ColorOptionRow(
     title: String,
     color: Int,
+    defaultColor: Int,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
     val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
+    val opaqueDefault = defaultColor.withOpaqueAlpha()
+    val defaultLabel = if (opaqueDefault == TIDAL_GREEN) {
+        stringResource(R.string.patch_color_green)
+    } else {
+        stringResource(R.string.patch_waze_color_waze_default)
+    }
     val presets = listOf(
-        stringResource(R.string.patch_waze_color_waze_default),
+        defaultLabel,
         stringResource(R.string.patch_waze_color_tidal_cyan),
         stringResource(R.string.patch_waze_color_material_you),
     )
-    val presetColors = listOf(WAZE_DEFAULT, TIDAL_CYAN, materialYouColor)
+    val presetColors = listOf(opaqueDefault, TIDAL_CYAN, materialYouColor)
     val selectedPreset = presetColors.indexOf(selectedColor)
 
     Column(
@@ -628,7 +636,7 @@ private fun formatSliderValue(option: OptionSpec.Slider, value: Float): String {
 }
 
 private const val OPAQUE_ALPHA = -0x1000000
-private const val WAZE_DEFAULT = -16747037 // #ff0075e3
+private const val TIDAL_GREEN = -14749031 // #ff1ef299
 private const val TIDAL_CYAN = -14549268 // #ff21feec
 
 private fun Int.withOpaqueAlpha(): Int = (this and 0x00FFFFFF) or OPAQUE_ALPHA

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -33,11 +33,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.meowarex.rlmobile.R
+import com.meowarex.rlmobile.ui.components.radiant.RadiantDropdown
 import com.meowarex.rlmobile.ui.legacy.components.ResetToDefaultButton
 import com.meowarex.rlmobile.ui.screens.patchopts.OptionLock
 import com.meowarex.rlmobile.ui.screens.patchopts.OptionSpec
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptionState
 import com.meowarex.rlmobile.ui.screens.patchopts.hiddenForVariant
+import com.meowarex.rlmobile.ui.screens.patchopts.isInline
 import com.meowarex.rlmobile.ui.screens.patchopts.optionLock
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchSpec
 import kotlinx.coroutines.launch
@@ -103,12 +105,12 @@ fun PatchAdvancedOptionsSheet(
 
             val parentKeys = patch.advancedOptions
                 .filterIsInstance<OptionSpec.Toggle>()
-                .filter { !it.inline }
+                .filter { !it.isInline }
                 .map { it.key }
                 .toSet()
             val sheetOptions = patch.advancedOptions.filter { option ->
                 when {
-                    option is OptionSpec.Toggle && option.inline -> false
+                    option.isInline -> false
                     option is OptionSpec.Toggle && option.requiresOption in parentKeys -> false
                     // Options belonging to another variant are hidden, not greyed out.
                     option.hiddenForVariant(selectedVariant) -> false
@@ -121,7 +123,7 @@ fun PatchAdvancedOptionsSheet(
                     is OptionSpec.Toggle -> {
                         val toggleOn = state.toggle(patch, option)
                         val gatedChoices = patch.advancedOptions.filterIsInstance<OptionSpec.Choice>()
-                            .filter { it.requiresOption == option.key }
+                            .filter { it.requiresOption == option.key && !it.isInline }
                         val gatedToggles = patch.advancedOptions.filterIsInstance<OptionSpec.Toggle>()
                             .filter { it.requiresOption == option.key && !it.inline }
                         val hasSubOptions = gatedChoices.isNotEmpty() || gatedToggles.isNotEmpty()
@@ -164,6 +166,7 @@ fun PatchAdvancedOptionsSheet(
                                             key(choice.key) {
                                                 ChoiceOptionRow(
                                                     title = choice.title,
+                                                    description = choice.description,
                                                     entries = choice.entries,
                                                     selectedIndex = state.choice(patch, choice),
                                                     forceDropdown = choice.forceDropdown,
@@ -208,6 +211,7 @@ fun PatchAdvancedOptionsSheet(
                         if (option.requiresOption == null) {
                             ChoiceOptionRow(
                                 title = option.title,
+                                description = option.description,
                                 entries = option.entries,
                                 selectedIndex = state.choice(patch, option),
                                 forceDropdown = option.forceDropdown,
@@ -387,11 +391,12 @@ private fun snapToNearestStep(
 }
 
 @Composable
-private fun ChoiceOptionRow(
+internal fun ChoiceOptionRow(
     entries: List<String>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     title: String = "",
+    description: String = "",
     forceDropdown: Boolean = false,
     disabledIndices: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
@@ -399,48 +404,28 @@ private fun ChoiceOptionRow(
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(6.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = Alignment.Start,
     ) {
         if (title.isNotEmpty()) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.labelMedium,
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
+        if (description.isNotEmpty()) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
             )
         }
         if (forceDropdown || entries.size > 3) {
-            var expanded by rememberSaveable { mutableStateOf(false) }
-            val selectedLabel = entries.getOrNull(selectedIndex).orEmpty()
-
-            Box(modifier = Modifier.fillMaxWidth()) {
-                OutlinedButton(
-                    onClick = { expanded = true },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        text = selectedLabel,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    entries.forEachIndexed { index, entry ->
-                        DropdownMenuItem(
-                            text = { Text(entry) },
-                            enabled = index !in disabledIndices,
-                            onClick = {
-                                onSelect(index)
-                                expanded = false
-                            },
-                        )
-                    }
-                }
-            }
+            RadiantDropdown(
+                options = entries,
+                selectedIndex = selectedIndex,
+                onSelect = onSelect,
+                disabledIndices = disabledIndices,
+            )
             return@Column
         }
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -223,7 +223,6 @@ fun PatchAdvancedOptionsSheet(
                         title = option.title,
                         color = state.color(patch, option),
                         defaultColor = option.default,
-                        manifestDefaultLabel = option.defaultLabel,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -472,22 +471,33 @@ private fun ColorOptionRow(
     title: String,
     color: Int,
     defaultColor: Int,
-    manifestDefaultLabel: String?,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
-    val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
-    val opaqueDefault = defaultColor.withOpaqueAlpha()
-    val defaultLabel = manifestDefaultLabel ?: if (opaqueDefault == TIDAL_GREEN) {
-        stringResource(R.string.patch_color_green)
-    } else stringResource(R.string.patch_waze_color_waze_default)
-    val presets = listOf(
-        defaultLabel,
-        stringResource(R.string.patch_waze_color_tidal_cyan),
-        stringResource(R.string.patch_waze_color_material_you),
-    )
-    val presetColors = listOf(opaqueDefault, TIDAL_CYAN, materialYouColor)
+    val isNeutralPalette = defaultColor.withOpaqueAlpha() == NEUTRAL
+    val presets = if (isNeutralPalette) {
+        listOf(
+            stringResource(R.string.patch_color_neutral),
+            stringResource(R.string.patch_color_green),
+            stringResource(R.string.patch_color_cyan),
+        )
+    } else {
+        listOf(
+            stringResource(R.string.patch_waze_color_waze_default),
+            stringResource(R.string.patch_waze_color_tidal_cyan),
+            stringResource(R.string.patch_waze_color_material_you),
+        )
+    }
+    val presetColors = if (isNeutralPalette) {
+        listOf(NEUTRAL, GREEN, CYAN)
+    } else {
+        listOf(
+            defaultColor.withOpaqueAlpha(),
+            TIDAL_CYAN,
+            MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha(),
+        )
+    }
     val selectedPreset = presetColors.indexOf(selectedColor)
 
     Column(
@@ -514,6 +524,12 @@ private fun ColorOptionRow(
                 text = selectedColor.toRgbHex(),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
+            )
+            Icon(
+                painter = painterResource(R.drawable.ic_edit),
+                contentDescription = stringResource(R.string.patch_color_edit),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
             )
         }
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
@@ -650,7 +666,9 @@ private fun formatSliderValue(option: OptionSpec.Slider, value: Float): String {
 }
 
 private const val OPAQUE_ALPHA = -0x1000000
-private const val TIDAL_GREEN = -14749031 // #ff1ef299
+private const val NEUTRAL = -14408663 // #ff242429
+private const val GREEN = -14749031 // #ff1ef299
+private const val CYAN = -14748953 // #ff1ef2e7
 private const val TIDAL_CYAN = -14549268 // #ff21feec
 
 private fun Int.withOpaqueAlpha(): Int = (this and 0x00FFFFFF) or OPAQUE_ALPHA

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchSelectionAccordion.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/legacy/screens/patchopts/components/PatchSelectionAccordion.kt
@@ -36,6 +36,8 @@ import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptions
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchSpec
 import com.meowarex.rlmobile.ui.screens.patchopts.effectiveVariants
 import com.meowarex.rlmobile.ui.screens.patchopts.resolveVariantIndex
+import com.meowarex.rlmobile.ui.screens.patchopts.conflictingChoices
+import com.meowarex.rlmobile.ui.screens.patchopts.isInline
 
 private data class LockInfo(val patch: PatchSpec, val lock: PatchLock)
 
@@ -131,11 +133,9 @@ fun PatchSelectionAccordion(
                     val checked = isEnabled(patch)
                     val lock = lockState(patch)
 
-                    val inlineToggles = patch.advancedOptions
-                        .filterIsInstance<OptionSpec.Toggle>()
-                        .filter { it.inline }
-                    val hasSheetOptions = patch.advancedOptions.any { it !is OptionSpec.Toggle || !it.inline }
-                    val hasSettings = patch.variants.isNotEmpty() || inlineToggles.isNotEmpty() || hasSheetOptions
+                    val inlineOptions = patch.advancedOptions.filter { it.isInline }
+                    val hasSheetOptions = patch.advancedOptions.any { !it.isInline }
+                    val hasSettings = patch.variants.isNotEmpty() || inlineOptions.isNotEmpty() || hasSheetOptions
 
                     // When a patch is enabled and has settings show a carded view of the settings
                     val carded = checked && hasSettings
@@ -191,16 +191,41 @@ fun PatchSelectionAccordion(
                                         )
                                     }
 
-                                    for (option in inlineToggles) key(option.key) {
-                                        val show = option.requiresVariant == null ||
-                                            option.requiresVariant == resolvedVariant
-                                        if (show) {
-                                            InlineToggleRow(
-                                                title = option.title,
-                                                description = option.description,
-                                                checked = optionState.toggle(patch, option),
-                                                onCheckedChange = { optionState.setToggle(patch, option, it) },
-                                            )
+                                    for (option in inlineOptions) key(option.key) {
+                                        when (option) {
+                                            is OptionSpec.Toggle -> {
+                                                val show = option.requiresVariant == null ||
+                                                    option.requiresVariant == resolvedVariant
+                                                if (show) {
+                                                    InlineToggleRow(
+                                                        title = option.title,
+                                                        description = option.description,
+                                                        checked = optionState.toggle(patch, option),
+                                                        onCheckedChange = { optionState.setToggle(patch, option, it) },
+                                                    )
+                                                }
+                                            }
+                                            is OptionSpec.Choice -> {
+                                                val requiredToggle = option.requiresOption?.let { key ->
+                                                    patch.advancedOptions.filterIsInstance<OptionSpec.Toggle>()
+                                                        .firstOrNull { it.key == key }
+                                                }
+                                                if (requiredToggle == null || optionState.toggle(patch, requiredToggle)) {
+                                                    ChoiceOptionRow(
+                                                        title = option.title,
+                                                        description = option.description,
+                                                        entries = option.entries,
+                                                        selectedIndex = optionState.choice(patch, option),
+                                                        forceDropdown = option.forceDropdown,
+                                                        disabledIndices = patch.conflictingChoices(option)
+                                                            .map { optionState.choice(patch, it) }
+                                                            .filter { it != 0 }
+                                                            .toSet(),
+                                                        onSelect = { optionState.setChoice(patch, option, it) },
+                                                    )
+                                                }
+                                            }
+                                            else -> Unit
                                         }
                                     }
 

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchOptionsModel.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchOptionsModel.kt
@@ -195,10 +195,9 @@ class PatchOptionsModel(
     }
 
     fun isAdvancedModified(spec: PatchSpec): Boolean = spec.advancedOptions.any { option ->
+        if (option.isInline) return@any false
         when (option) {
-            // inline toggles sit next to the variant picker, not in the sheet, so they
-            // must not light up the sheet's "modified" dot
-            is OptionSpec.Toggle -> !option.inline && toggleValue(spec, option) != option.default
+            is OptionSpec.Toggle -> toggleValue(spec, option) != option.default
             is OptionSpec.Slider -> sliderValue(spec, option) != option.default
             is OptionSpec.Choice -> choiceValue(spec, option) != option.defaultIndex
             is OptionSpec.Color -> colorValue(spec, option) != option.default
@@ -206,12 +205,17 @@ class PatchOptionsModel(
     }
 
     fun resetAdvanced(spec: PatchSpec) {
-        val prefix = "${spec.id}/"
-        optionBools = optionBools.filterKeys { !it.startsWith(prefix) }
-        optionFloats = optionFloats.filterKeys { !it.startsWith(prefix) }
+        val advancedOptions = spec.advancedOptions.filter { !it.isInline }
+        val boolKeys = advancedOptions.filterIsInstance<OptionSpec.Toggle>().map { keyOf(spec, it) }.toSet()
+        val floatKeys = advancedOptions.filterIsInstance<OptionSpec.Slider>().map { keyOf(spec, it) }.toSet()
+        val intKeys = advancedOptions.filter { it is OptionSpec.Choice || it is OptionSpec.Color }
+            .map { keyOf(spec, it) }
+            .toSet()
+        optionBools = optionBools.filterKeys { it !in boolKeys }
+        optionFloats = optionFloats.filterKeys { it !in floatKeys }
         optionInts = normalizeChoiceSelections(
             specs = listOf(spec),
-            values = optionInts.filterKeys { !it.startsWith(prefix) },
+            values = optionInts.filterKeys { it !in intKeys },
         )
     }
 

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchOptionsModel.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchOptionsModel.kt
@@ -179,7 +179,12 @@ class PatchOptionsModel(
 
     fun setChoiceValue(spec: PatchSpec, option: OptionSpec.Choice, index: Int) {
         if (index !in option.entries.indices) return
-        optionInts = optionInts + (keyOf(spec, option) to index)
+        val selectedKey = keyOf(spec, option)
+        optionInts = normalizeChoiceSelections(
+            specs = listOf(spec),
+            values = optionInts + (selectedKey to index),
+            preferredKey = selectedKey,
+        )
     }
 
     fun colorValue(spec: PatchSpec, option: OptionSpec.Color): Int =
@@ -204,7 +209,14 @@ class PatchOptionsModel(
         val prefix = "${spec.id}/"
         optionBools = optionBools.filterKeys { !it.startsWith(prefix) }
         optionFloats = optionFloats.filterKeys { !it.startsWith(prefix) }
-        optionInts = optionInts.filterKeys { !it.startsWith(prefix) }
+        optionInts = normalizeChoiceSelections(
+            specs = listOf(spec),
+            values = optionInts.filterKeys { !it.startsWith(prefix) },
+        )
+    }
+
+    private fun normalizeChoiceSelections(specs: List<PatchSpec>) {
+        optionInts = normalizeChoiceSelections(specs, optionInts)
     }
 
     val optionState: PatchOptionState = PatchOptionState(
@@ -282,6 +294,7 @@ class PatchOptionsModel(
         val loaded = if (component == null) builtinSpecs else loadManifestSpecs(component) ?: builtinSpecs
         mainThread {
             specs = loaded
+            normalizeChoiceSelections(loaded)
             validatePatchSelection()
             specsLoading = false
         }
@@ -351,6 +364,7 @@ class PatchOptionsModel(
             ?: loadCachedReleaseManifestSpecs() ?: builtinSpecs
         mainThread {
             specs = loaded
+            normalizeChoiceSelections(loaded)
             validatePatchSelection()
             specsLoading = false
         }
@@ -415,6 +429,7 @@ class PatchOptionsModel(
     }
 
     init {
+        normalizeChoiceSelections(specs)
         validatePatchSelection()
         screenModelScope.launchBlock { fetchPkgNameState() }
         // Default source is the latest release's manifest; custom selections drive themselves.

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
@@ -125,6 +125,8 @@ sealed interface OptionSpec {
         val defaultIndex: Int = 0,
         val values: List<String> = emptyList(),
         val requiresOption: String? = null,
+        val forceDropdown: Boolean = false,
+        val distinctFrom: String? = null,
         val token: String? = null,
     ) : OptionSpec
 
@@ -136,6 +138,7 @@ sealed interface OptionSpec {
         override val title: String = "",
         override val description: String = "",
         val default: Int = 0,
+        val defaultLabel: String? = null,
         /** Placeholder name (without the surrounding `__`) baked into the `.patch`/extension files. */
         val token: String? = null,
     ) : OptionSpec
@@ -230,6 +233,41 @@ val OptionSpec.variantGate: Int?
 
 fun OptionSpec.hiddenForVariant(selectedVariant: Int): Boolean =
     variantGate.let { it != null && it != selectedVariant }
+
+fun PatchSpec.conflictingChoices(option: OptionSpec.Choice): List<OptionSpec.Choice> =
+    advancedOptions.filterIsInstance<OptionSpec.Choice>().filter { other ->
+        other.key != option.key &&
+                (option.distinctFrom == other.key || other.distinctFrom == option.key)
+    }
+
+internal fun normalizeChoiceSelections(
+    specs: List<PatchSpec>,
+    values: Map<String, Int>,
+    preferredKey: String? = null,
+): Map<String, Int> {
+    val normalized = values.toMutableMap()
+    for (spec in specs) {
+        val choices = spec.advancedOptions.filterIsInstance<OptionSpec.Choice>()
+        fun fullKey(option: OptionSpec.Choice) = "${spec.id}/${option.key}"
+        fun selected(option: OptionSpec.Choice): Int =
+            (normalized[fullKey(option)] ?: option.defaultIndex)
+                .coerceIn(0, option.entries.lastIndex.coerceAtLeast(0))
+
+        for (leftIndex in choices.indices) {
+            val left = choices[leftIndex]
+            for (rightIndex in leftIndex + 1 until choices.size) {
+                val right = choices[rightIndex]
+                if (left.distinctFrom != right.key && right.distinctFrom != left.key) continue
+                val selected = selected(left)
+                if (selected == 0 || selected != selected(right)) continue
+
+                val loser = if (preferredKey == fullKey(right)) left else right
+                normalized[fullKey(loser)] = 0
+            }
+        }
+    }
+    return if (normalized == values) values else normalized
+}
 
 sealed interface OptionLock {
     data object Free : OptionLock

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
@@ -138,7 +138,6 @@ sealed interface OptionSpec {
         override val title: String = "",
         override val description: String = "",
         val default: Int = 0,
-        val defaultLabel: String? = null,
         /** Placeholder name (without the surrounding `__`) baked into the `.patch`/extension files. */
         val token: String? = null,
     ) : OptionSpec

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/PatchSpec.kt
@@ -126,6 +126,8 @@ sealed interface OptionSpec {
         val values: List<String> = emptyList(),
         val requiresOption: String? = null,
         val forceDropdown: Boolean = false,
+        /** Render inline in the patch card instead of inside the advanced sheet */
+        val inline: Boolean = false,
         val distinctFrom: String? = null,
         val token: String? = null,
     ) : OptionSpec
@@ -142,6 +144,13 @@ sealed interface OptionSpec {
         val token: String? = null,
     ) : OptionSpec
 }
+
+val OptionSpec.isInline: Boolean
+    get() = when (this) {
+        is OptionSpec.Toggle -> inline
+        is OptionSpec.Choice -> inline
+        is OptionSpec.Slider, is OptionSpec.Color -> false
+    }
 
 @Serializable
 enum class EncodeKind {

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -43,6 +43,7 @@ import com.meowarex.rlmobile.ui.components.ResetToDefaultButton
 import com.meowarex.rlmobile.ui.screens.patchopts.OptionLock
 import com.meowarex.rlmobile.ui.screens.patchopts.OptionSpec
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptionState
+import com.meowarex.rlmobile.ui.screens.patchopts.conflictingChoices
 import com.meowarex.rlmobile.ui.screens.patchopts.hiddenForVariant
 import com.meowarex.rlmobile.ui.screens.patchopts.optionLock
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchSpec
@@ -172,6 +173,11 @@ fun PatchAdvancedOptionsSheet(
                                                     title = choice.title,
                                                     entries = choice.entries,
                                                     selectedIndex = state.choice(patch, choice),
+                                                    forceDropdown = choice.forceDropdown,
+                                                    disabledIndices = patch.conflictingChoices(choice)
+                                                        .map { state.choice(patch, it) }
+                                                        .filter { it != 0 }
+                                                        .toSet(),
                                                     onSelect = { state.setChoice(patch, choice, it) },
                                                 )
                                             }
@@ -211,6 +217,11 @@ fun PatchAdvancedOptionsSheet(
                                 title = option.title,
                                 entries = option.entries,
                                 selectedIndex = state.choice(patch, option),
+                                forceDropdown = option.forceDropdown,
+                                disabledIndices = patch.conflictingChoices(option)
+                                    .map { state.choice(patch, it) }
+                                    .filter { it != 0 }
+                                    .toSet(),
                                 onSelect = { state.setChoice(patch, option, it) },
                             )
                         }
@@ -219,6 +230,7 @@ fun PatchAdvancedOptionsSheet(
                         title = option.title,
                         color = state.color(patch, option),
                         defaultColor = option.default,
+                        manifestDefaultLabel = option.defaultLabel,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -382,6 +394,8 @@ private fun ChoiceOptionRow(
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     title: String = "",
+    forceDropdown: Boolean = false,
+    disabledIndices: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -397,7 +411,7 @@ private fun ChoiceOptionRow(
                 textAlign = TextAlign.Center,
             )
         }
-        if (entries.size > 3) {
+        if (forceDropdown || entries.size > 3) {
             var expanded by rememberSaveable { mutableStateOf(false) }
             val selectedLabel = entries.getOrNull(selectedIndex).orEmpty()
 
@@ -416,6 +430,7 @@ private fun ChoiceOptionRow(
                     entries.forEachIndexed { index, entry ->
                         DropdownMenuItem(
                             text = { Text(entry) },
+                            enabled = index !in disabledIndices,
                             onClick = {
                                 onSelect(index)
                                 expanded = false
@@ -430,6 +445,7 @@ private fun ChoiceOptionRow(
             options = entries,
             selectedIndex = selectedIndex,
             onSelect = onSelect,
+            disabledIndices = disabledIndices,
         )
     }
 }
@@ -439,17 +455,16 @@ private fun ColorOptionRow(
     title: String,
     color: Int,
     defaultColor: Int,
+    manifestDefaultLabel: String?,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
     val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
     val opaqueDefault = defaultColor.withOpaqueAlpha()
-    val defaultLabel = if (opaqueDefault == TIDAL_GREEN) {
+    val defaultLabel = manifestDefaultLabel ?: if (opaqueDefault == TIDAL_GREEN) {
         stringResource(R.string.patch_color_green)
-    } else {
-        stringResource(R.string.patch_waze_color_waze_default)
-    }
+    } else stringResource(R.string.patch_waze_color_waze_default)
     val presets = listOf(
         defaultLabel,
         stringResource(R.string.patch_waze_color_tidal_cyan),

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -218,6 +218,7 @@ fun PatchAdvancedOptionsSheet(
                     is OptionSpec.Color -> ColorOptionRow(
                         title = option.title,
                         color = state.color(patch, option),
+                        defaultColor = option.default,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -437,17 +438,24 @@ private fun ChoiceOptionRow(
 private fun ColorOptionRow(
     title: String,
     color: Int,
+    defaultColor: Int,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
     val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
+    val opaqueDefault = defaultColor.withOpaqueAlpha()
+    val defaultLabel = if (opaqueDefault == TIDAL_GREEN) {
+        stringResource(R.string.patch_color_green)
+    } else {
+        stringResource(R.string.patch_waze_color_waze_default)
+    }
     val presets = listOf(
-        stringResource(R.string.patch_waze_color_waze_default),
+        defaultLabel,
         stringResource(R.string.patch_waze_color_tidal_cyan),
         stringResource(R.string.patch_waze_color_material_you),
     )
-    val presetColors = listOf(WAZE_DEFAULT, TIDAL_CYAN, materialYouColor)
+    val presetColors = listOf(opaqueDefault, TIDAL_CYAN, materialYouColor)
     val selectedPreset = presetColors.indexOf(selectedColor)
 
     Column(
@@ -588,7 +596,7 @@ private fun formatSliderValue(option: OptionSpec.Slider, value: Float): String {
 }
 
 private const val OPAQUE_ALPHA = -0x1000000
-private const val WAZE_DEFAULT = -16747037 // #ff0075e3
+private const val TIDAL_GREEN = -14749031 // #ff1ef299
 private const val TIDAL_CYAN = -14549268 // #ff21feec
 
 private fun Int.withOpaqueAlpha(): Int = (this and 0x00FFFFFF) or OPAQUE_ALPHA

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.meowarex.rlmobile.R
 import com.meowarex.rlmobile.ui.components.radiant.RadiantButton
 import com.meowarex.rlmobile.ui.components.radiant.RadiantDialog
+import com.meowarex.rlmobile.ui.components.radiant.RadiantDropdown
 import com.meowarex.rlmobile.ui.components.radiant.RadiantButtonSize
 import com.meowarex.rlmobile.ui.components.radiant.RadiantButtonStyle
 import com.meowarex.rlmobile.ui.components.radiant.RadiantIconButton
@@ -45,6 +46,7 @@ import com.meowarex.rlmobile.ui.screens.patchopts.OptionSpec
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptionState
 import com.meowarex.rlmobile.ui.screens.patchopts.conflictingChoices
 import com.meowarex.rlmobile.ui.screens.patchopts.hiddenForVariant
+import com.meowarex.rlmobile.ui.screens.patchopts.isInline
 import com.meowarex.rlmobile.ui.screens.patchopts.optionLock
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchSpec
 import kotlinx.coroutines.launch
@@ -110,12 +112,12 @@ fun PatchAdvancedOptionsSheet(
 
             val parentKeys = patch.advancedOptions
                 .filterIsInstance<OptionSpec.Toggle>()
-                .filter { !it.inline }
+                .filter { !it.isInline }
                 .map { it.key }
                 .toSet()
             val sheetOptions = patch.advancedOptions.filter { option ->
                 when {
-                    option is OptionSpec.Toggle && option.inline -> false
+                    option.isInline -> false
                     option is OptionSpec.Toggle && option.requiresOption in parentKeys -> false
                     // Options belonging to another variant are hidden, not greyed out.
                     option.hiddenForVariant(selectedVariant) -> false
@@ -128,7 +130,7 @@ fun PatchAdvancedOptionsSheet(
                     is OptionSpec.Toggle -> {
                         val toggleOn = state.toggle(patch, option)
                         val gatedChoices = patch.advancedOptions.filterIsInstance<OptionSpec.Choice>()
-                            .filter { it.requiresOption == option.key }
+                            .filter { it.requiresOption == option.key && !it.isInline }
                         val gatedToggles = patch.advancedOptions.filterIsInstance<OptionSpec.Toggle>()
                             .filter { it.requiresOption == option.key && !it.inline }
                         val hasSubOptions = gatedChoices.isNotEmpty() || gatedToggles.isNotEmpty()
@@ -171,6 +173,7 @@ fun PatchAdvancedOptionsSheet(
                                             key(choice.key) {
                                                 ChoiceOptionRow(
                                                     title = choice.title,
+                                                    description = choice.description,
                                                     entries = choice.entries,
                                                     selectedIndex = state.choice(patch, choice),
                                                     forceDropdown = choice.forceDropdown,
@@ -215,6 +218,7 @@ fun PatchAdvancedOptionsSheet(
                         if (option.requiresOption == null) {
                             ChoiceOptionRow(
                                 title = option.title,
+                                description = option.description,
                                 entries = option.entries,
                                 selectedIndex = state.choice(patch, option),
                                 forceDropdown = option.forceDropdown,
@@ -388,11 +392,12 @@ private fun snapToNearestStep(
 }
 
 @Composable
-private fun ChoiceOptionRow(
+internal fun ChoiceOptionRow(
     entries: List<String>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     title: String = "",
+    description: String = "",
     forceDropdown: Boolean = false,
     disabledIndices: Set<Int> = emptySet(),
     modifier: Modifier = Modifier,
@@ -400,44 +405,28 @@ private fun ChoiceOptionRow(
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(6.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = Alignment.Start,
     ) {
         if (title.isNotEmpty()) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.labelMedium,
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
+        if (description.isNotEmpty()) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
             )
         }
         if (forceDropdown || entries.size > 3) {
-            var expanded by rememberSaveable { mutableStateOf(false) }
-            val selectedLabel = entries.getOrNull(selectedIndex).orEmpty()
-
-            Box(modifier = Modifier.fillMaxWidth()) {
-                RadiantButton(
-                    text = selectedLabel,
-                    onClick = { expanded = true },
-                    style = RadiantButtonStyle.Ghost,
-                    fillWidth = true,
-                )
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    entries.forEachIndexed { index, entry ->
-                        DropdownMenuItem(
-                            text = { Text(entry) },
-                            enabled = index !in disabledIndices,
-                            onClick = {
-                                onSelect(index)
-                                expanded = false
-                            },
-                        )
-                    }
-                }
-            }
+            RadiantDropdown(
+                options = entries,
+                selectedIndex = selectedIndex,
+                onSelect = onSelect,
+                disabledIndices = disabledIndices,
+            )
             return@Column
         }
         RadiantSegmented(

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchAdvancedOptionsSheet.kt
@@ -230,7 +230,6 @@ fun PatchAdvancedOptionsSheet(
                         title = option.title,
                         color = state.color(patch, option),
                         defaultColor = option.default,
-                        manifestDefaultLabel = option.defaultLabel,
                         onColorChange = { state.setColor(patch, option, it) },
                     )
                 }
@@ -455,22 +454,33 @@ private fun ColorOptionRow(
     title: String,
     color: Int,
     defaultColor: Int,
-    manifestDefaultLabel: String?,
     onColorChange: (Int) -> Unit,
 ) {
     var showPicker by rememberSaveable { mutableStateOf(false) }
     val selectedColor = color.withOpaqueAlpha()
-    val materialYouColor = MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha()
-    val opaqueDefault = defaultColor.withOpaqueAlpha()
-    val defaultLabel = manifestDefaultLabel ?: if (opaqueDefault == TIDAL_GREEN) {
-        stringResource(R.string.patch_color_green)
-    } else stringResource(R.string.patch_waze_color_waze_default)
-    val presets = listOf(
-        defaultLabel,
-        stringResource(R.string.patch_waze_color_tidal_cyan),
-        stringResource(R.string.patch_waze_color_material_you),
-    )
-    val presetColors = listOf(opaqueDefault, TIDAL_CYAN, materialYouColor)
+    val isNeutralPalette = defaultColor.withOpaqueAlpha() == NEUTRAL
+    val presets = if (isNeutralPalette) {
+        listOf(
+            stringResource(R.string.patch_color_neutral),
+            stringResource(R.string.patch_color_green),
+            stringResource(R.string.patch_color_cyan),
+        )
+    } else {
+        listOf(
+            stringResource(R.string.patch_waze_color_waze_default),
+            stringResource(R.string.patch_waze_color_tidal_cyan),
+            stringResource(R.string.patch_waze_color_material_you),
+        )
+    }
+    val presetColors = if (isNeutralPalette) {
+        listOf(NEUTRAL, GREEN, CYAN)
+    } else {
+        listOf(
+            defaultColor.withOpaqueAlpha(),
+            TIDAL_CYAN,
+            MaterialTheme.colorScheme.primary.toArgb().withOpaqueAlpha(),
+        )
+    }
     val selectedPreset = presetColors.indexOf(selectedColor)
 
     Column(
@@ -497,6 +507,12 @@ private fun ColorOptionRow(
                 text = selectedColor.toRgbHex(),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
+            )
+            Icon(
+                painter = painterResource(R.drawable.ic_edit),
+                contentDescription = stringResource(R.string.patch_color_edit),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
             )
         }
         RadiantSegmented(
@@ -611,7 +627,9 @@ private fun formatSliderValue(option: OptionSpec.Slider, value: Float): String {
 }
 
 private const val OPAQUE_ALPHA = -0x1000000
-private const val TIDAL_GREEN = -14749031 // #ff1ef299
+private const val NEUTRAL = -14408663 // #ff242429
+private const val GREEN = -14749031 // #ff1ef299
+private const val CYAN = -14748953 // #ff1ef2e7
 private const val TIDAL_CYAN = -14549268 // #ff21feec
 
 private fun Int.withOpaqueAlpha(): Int = (this and 0x00FFFFFF) or OPAQUE_ALPHA

--- a/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchSelectionAccordion.kt
+++ b/Manager/app/src/main/kotlin/com/meowarex/rlmobile/ui/screens/patchopts/components/PatchSelectionAccordion.kt
@@ -33,6 +33,8 @@ import com.meowarex.rlmobile.ui.components.radiant.RadiantDialog
 import com.meowarex.rlmobile.ui.theme.radiantSurface
 import com.meowarex.rlmobile.ui.theme.glassSurface
 import com.meowarex.rlmobile.ui.screens.patchopts.OptionSpec
+import com.meowarex.rlmobile.ui.screens.patchopts.conflictingChoices
+import com.meowarex.rlmobile.ui.screens.patchopts.isInline
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchLock
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptionState
 import com.meowarex.rlmobile.ui.screens.patchopts.PatchOptions
@@ -134,11 +136,9 @@ fun PatchSelectionAccordion(
                     val checked = isEnabled(patch)
                     val lock = lockState(patch)
 
-                    val inlineToggles = patch.advancedOptions
-                        .filterIsInstance<OptionSpec.Toggle>()
-                        .filter { it.inline }
-                    val hasSheetOptions = patch.advancedOptions.any { it !is OptionSpec.Toggle || !it.inline }
-                    val hasSettings = patch.variants.isNotEmpty() || inlineToggles.isNotEmpty() || hasSheetOptions
+                    val inlineOptions = patch.advancedOptions.filter { it.isInline }
+                    val hasSheetOptions = patch.advancedOptions.any { !it.isInline }
+                    val hasSettings = patch.variants.isNotEmpty() || inlineOptions.isNotEmpty() || hasSheetOptions
 
                     // When a patch is enabled and has settings show a carded view of the settings
                     val carded = checked && hasSettings
@@ -189,16 +189,41 @@ fun PatchSelectionAccordion(
                                         )
                                     }
 
-                                    for (option in inlineToggles) key(option.key) {
-                                        val show = option.requiresVariant == null ||
-                                            option.requiresVariant == resolvedVariant
-                                        if (show) {
-                                            InlineToggleRow(
-                                                title = option.title,
-                                                description = option.description,
-                                                checked = optionState.toggle(patch, option),
-                                                onCheckedChange = { optionState.setToggle(patch, option, it) },
-                                            )
+                                    for (option in inlineOptions) key(option.key) {
+                                        when (option) {
+                                            is OptionSpec.Toggle -> {
+                                                val show = option.requiresVariant == null ||
+                                                    option.requiresVariant == resolvedVariant
+                                                if (show) {
+                                                    InlineToggleRow(
+                                                        title = option.title,
+                                                        description = option.description,
+                                                        checked = optionState.toggle(patch, option),
+                                                        onCheckedChange = { optionState.setToggle(patch, option, it) },
+                                                    )
+                                                }
+                                            }
+                                            is OptionSpec.Choice -> {
+                                                val requiredToggle = option.requiresOption?.let { key ->
+                                                    patch.advancedOptions.filterIsInstance<OptionSpec.Toggle>()
+                                                        .firstOrNull { it.key == key }
+                                                }
+                                                if (requiredToggle == null || optionState.toggle(patch, requiredToggle)) {
+                                                    ChoiceOptionRow(
+                                                        title = option.title,
+                                                        description = option.description,
+                                                        entries = option.entries,
+                                                        selectedIndex = optionState.choice(patch, option),
+                                                        forceDropdown = option.forceDropdown,
+                                                        disabledIndices = patch.conflictingChoices(option)
+                                                            .map { optionState.choice(patch, it) }
+                                                            .filter { it != 0 }
+                                                            .toSet(),
+                                                        onSelect = { optionState.setChoice(patch, option, it) },
+                                                    )
+                                                }
+                                            }
+                                            else -> Unit
                                         }
                                     }
 

--- a/Manager/app/src/main/res/drawable/ic_edit.xml
+++ b/Manager/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#e8eaed"
+      android:pathData="M200,760h57l391,-391l-57,-57l-391,391v57zM160,840q-17,0 -28.5,-11.5T120,800v-97q0,-16 6,-30.5t17,-25.5l505,-504q12,-11 26.5,-17t30.5,-6q16,0 31,6t26,18l55,56q12,11 17.5,26t5.5,30q0,16 -5.5,30.5T817,313L313,817q-11,11 -25.5,17t-30.5,6h-97zM760,256l-56,-56l56,56zM619,341l-28,-29l57,57l-29,-28z" />
+</vector>

--- a/Manager/app/src/main/res/values/strings.xml
+++ b/Manager/app/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
   <string name="patch_waze_browse_root_title">Media Menu</string>
   <string name="patch_waze_accent_color_title">Accent Color</string>
   <string name="patch_waze_color_waze_default">Waze Default</string>
+  <string name="patch_color_green">Green</string>
   <string name="patch_waze_color_tidal_cyan">TIDAL Cyan</string>
   <string name="patch_waze_color_material_you">Material You</string>
   <string name="patch_waze_root_auto">Auto Menu</string>

--- a/Manager/app/src/main/res/values/strings.xml
+++ b/Manager/app/src/main/res/values/strings.xml
@@ -305,13 +305,16 @@
   <string name="patch_waze_browse_root_title">Media Menu</string>
   <string name="patch_waze_accent_color_title">Accent Color</string>
   <string name="patch_waze_color_waze_default">Waze Default</string>
+  <string name="patch_color_neutral">Neutral</string>
   <string name="patch_color_green">Green</string>
+  <string name="patch_color_cyan">Cyan</string>
   <string name="patch_waze_color_tidal_cyan">TIDAL Cyan</string>
   <string name="patch_waze_color_material_you">Material You</string>
   <string name="patch_waze_root_auto">Auto Menu</string>
   <string name="patch_waze_root_home">Home</string>
   <string name="patch_waze_root_recents">Recents</string>
   <string name="patch_color_picker_title">Custom color</string>
+  <string name="patch_color_edit">Choose custom color</string>
   <string name="patch_color_picker_hex">Hex color</string>
   <string name="patch_color_picker_hex_error">Use #RRGGBB or #AARRGGBB.</string>
   <string name="patch_enable_legacy_ui_title">Enable Legacy UI</string>

--- a/patches/data.json
+++ b/patches/data.json
@@ -1,5 +1,5 @@
 {
   "tidalVersionCode": 10004,
   "tidalApkUrl": "https://github.com/meowarex/rl-mobile/releases/download/latest/tidal-stock.apk",
-  "patchesVersion": "1.2.5"
+  "patchesVersion": "1.2.6"
 }

--- a/patches/extension/radiant/MiniPlayerBackground.smali
+++ b/patches/extension/radiant/MiniPlayerBackground.smali
@@ -3,22 +3,20 @@
 
 
 # static fields
-.field public static final colorState:Landroidx/compose/runtime/MutableState; # player bg color
+.field public static final colorFlow:Lkotlinx/coroutines/flow/MutableStateFlow; # player bg color
 
 
 # direct methods
 .method static constructor <clinit>()V
-    .locals 2
+    .locals 1
 
     const/4 v0, 0x0
 
-    const/4 v1, 0x2
-
-    invoke-static {v0, v0, v1, v0}, Landroidx/compose/runtime/SnapshotStateKt;->mutableStateOf$default(Ljava/lang/Object;Landroidx/compose/runtime/SnapshotMutationPolicy;ILjava/lang/Object;)Landroidx/compose/runtime/MutableState;
+    invoke-static {v0}, Lkotlinx/coroutines/flow/StateFlowKt;->MutableStateFlow(Ljava/lang/Object;)Lkotlinx/coroutines/flow/MutableStateFlow;
 
     move-result-object v0
 
-    sput-object v0, Lradiant/MiniPlayerBackground;->colorState:Landroidx/compose/runtime/MutableState;
+    sput-object v0, Lradiant/MiniPlayerBackground;->colorFlow:Lkotlinx/coroutines/flow/MutableStateFlow;
 
     return-void
 .end method
@@ -42,9 +40,19 @@
 
     invoke-interface {p2, v0}, Landroidx/compose/runtime/Composer;->startReplaceGroup(I)V
 
-    sget-object v0, Lradiant/MiniPlayerBackground;->colorState:Landroidx/compose/runtime/MutableState;
+    sget-object v0, Lradiant/MiniPlayerBackground;->colorFlow:Lkotlinx/coroutines/flow/MutableStateFlow;
 
-    invoke-interface {v0}, Landroidx/compose/runtime/MutableState;->getValue()Ljava/lang/Object; # read player color
+    const/4 v1, 0x0
+
+    const/4 v3, 0x0
+
+    const/4 v4, 0x1
+
+    invoke-static {v0, v1, p2, v3, v4}, Landroidx/compose/runtime/SnapshotStateKt;->collectAsState(Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/h;Landroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/State;
+
+    move-result-object v0
+
+    invoke-interface {v0}, Landroidx/compose/runtime/State;->getValue()Ljava/lang/Object;
 
     move-result-object v0
 
@@ -131,9 +139,9 @@
     move-exception p0
 
     :set_color
-    sget-object p0, Lradiant/MiniPlayerBackground;->colorState:Landroidx/compose/runtime/MutableState;
+    sget-object p0, Lradiant/MiniPlayerBackground;->colorFlow:Lkotlinx/coroutines/flow/MutableStateFlow;
 
-    invoke-interface {p0, v0}, Landroidx/compose/runtime/MutableState;->setValue(Ljava/lang/Object;)V
+    invoke-interface {p0, v0}, Lkotlinx/coroutines/flow/MutableStateFlow;->setValue(Ljava/lang/Object;)V
 
     return-void
 .end method

--- a/patches/extension/radiant/QueueSwipeRemove.smali
+++ b/patches/extension/radiant/QueueSwipeRemove.smali
@@ -1,0 +1,222 @@
+.class public final Lradiant/QueueSwipeRemove;
+.super Ljava/lang/Object;
+.source "QueueSwipeRemove.smali"
+
+
+# direct methods
+.method public static draw(Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FIZ)V
+    .locals 10
+
+    const/4 v0, 0x1
+
+    if-ne p4, v0, :done
+
+    iget-object v0, p2, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->itemView:Landroid/view/View;
+
+    const/4 v1, 0x0
+
+    int-to-float v1, v1
+
+    cmpg-float v2, p3, v1
+
+    invoke-virtual {v0}, Landroid/view/View;->getTop()I
+
+    move-result v3
+
+    invoke-virtual {v0}, Landroid/view/View;->getBottom()I
+
+    move-result v4
+
+    if-gez v2, :right_swipe
+
+    # left swipe
+    invoke-virtual {v0}, Landroid/view/View;->getRight()I
+
+    move-result v1
+
+    float-to-int v2, p3
+
+    add-int/2addr v2, v1
+
+    goto :bounds_ready
+
+    :right_swipe
+    cmpl-float v1, p3, v1
+
+    if-lez v1, :done
+
+    # right swipe
+    invoke-virtual {v0}, Landroid/view/View;->getLeft()I
+
+    move-result v2
+
+    float-to-int v1, p3
+
+    add-int/2addr v1, v2
+
+    :bounds_ready
+    sub-int v5, v1, v2
+
+    if-lez v5, :done
+
+    iget-object v6, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->c:Landroid/graphics/drawable/ColorDrawable;
+
+    invoke-virtual {v6, v2, v3, v1, v4}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
+
+    invoke-virtual {v0}, Landroid/view/View;->getWidth()I
+
+    move-result v7
+
+    if-lez v7, :draw_background
+
+    # 30% threshold
+    mul-int/lit8 v8, v7, 0x3
+
+    div-int/lit8 v8, v8, 0xa
+
+    if-eqz p5, :draw_alpha
+
+    if-lt v5, v8, :below_threshold
+
+    const/4 v9, 0x1
+
+    goto :update_haptic
+
+    :below_threshold
+    const/4 v9, 0x0
+
+    :update_haptic
+    iget-boolean p2, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->i:Z
+
+    if-eq v9, p2, :draw_alpha
+
+    iput-boolean v9, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->i:Z
+
+    # CLOCK_TICK
+    const/4 p2, 0x4
+
+    invoke-virtual {v0, p2}, Landroid/view/View;->performHapticFeedback(I)Z
+
+    :draw_alpha
+    const/16 v9, 0x40
+
+    mul-int/2addr v9, v5
+
+    div-int/2addr v9, v8
+
+    const/16 v8, 0x40
+
+    invoke-static {v9, v8}, Ljava/lang/Math;->min(II)I
+
+    move-result v8
+
+    add-int/lit16 v8, v8, 0xbf
+
+    invoke-virtual {v6, v8}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
+
+    :draw_background
+    invoke-virtual {v6, p1}, Landroid/graphics/drawable/ColorDrawable;->draw(Landroid/graphics/Canvas;)V
+
+    iget-object v6, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->h:Landroid/graphics/drawable/Drawable;
+
+    if-eqz v6, :done
+
+    invoke-virtual {v6}, Landroid/graphics/drawable/Drawable;->getIntrinsicWidth()I
+
+    move-result v7
+
+    invoke-virtual {v6}, Landroid/graphics/drawable/Drawable;->getIntrinsicHeight()I
+
+    move-result v8
+
+    if-lez v7, :done
+
+    if-lez v8, :done
+
+    sub-int v9, v4, v3
+
+    sub-int/2addr v9, v8
+
+    div-int/lit8 v9, v9, 0x2
+
+    const/4 p2, 0x0
+
+    int-to-float p2, p2
+
+    cmpg-float p2, p3, p2
+
+    if-gez p2, :right_icon
+
+    sub-int p2, v1, v9
+
+    sub-int p4, p2, v7
+
+    add-int p2, v5, v7
+
+    div-int/lit8 p2, p2, 0x2
+
+    sub-int p2, v1, p2
+
+    invoke-static {p2, p4}, Ljava/lang/Math;->max(II)I
+
+    move-result p2
+
+    goto :icon_positioned
+
+    :right_icon
+    add-int p2, v2, v9
+
+    sub-int p4, v5, v7
+
+    div-int/lit8 p4, p4, 0x2
+
+    add-int/2addr p4, v2
+
+    invoke-static {p4, p2}, Ljava/lang/Math;->min(II)I
+
+    move-result p2
+
+    :icon_positioned
+    add-int p4, p2, v7
+
+    invoke-virtual {p1}, Landroid/graphics/Canvas;->save()I
+
+    move-result v7
+
+    invoke-virtual {p1, v2, v3, v1, v4}, Landroid/graphics/Canvas;->clipRect(IIII)Z
+
+    add-int v2, v3, v9
+
+    add-int v3, v2, v8
+
+    invoke-virtual {v6, p2, v2, p4, v3}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
+
+    const/16 v8, 0xff
+
+    invoke-virtual {v6, v8}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
+
+    invoke-virtual {v6, p1}, Landroid/graphics/drawable/Drawable;->draw(Landroid/graphics/Canvas;)V
+
+    invoke-virtual {p1, v7}, Landroid/graphics/Canvas;->restoreToCount(I)V
+
+    :done
+    return-void
+.end method
+
+.method public static setRemoveDuration(Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 2
+
+    invoke-virtual {p0}, Landroidx/recyclerview/widget/RecyclerView;->getItemAnimator()Landroidx/recyclerview/widget/RecyclerView$ItemAnimator;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    # 80ms (faster animation, native is 120ms)
+    const-wide/16 v0, 0x50
+
+    invoke-virtual {p0, v0, v1}, Landroidx/recyclerview/widget/RecyclerView$ItemAnimator;->setRemoveDuration(J)V
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/QueueSwipeRemove.smali
+++ b/patches/extension/radiant/QueueSwipeRemove.smali
@@ -74,6 +74,8 @@
 
     div-int/lit8 v8, v8, 0xa
 
+    if-lez v8, :draw_background
+
     if-eqz p5, :draw_alpha
 
     if-lt v5, v8, :below_threshold

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -49,11 +49,7 @@
 
     new-instance v1, Landroid/graphics/drawable/ColorDrawable;
 
-    sget v2, Lcom/aspiro/wamp/R$color;->green:I
-
-    invoke-virtual {v0, v2}, Landroid/content/Context;->getColor(I)I
-
-    move-result v2
+    const v2, __RL_SWIPE_TO_QUEUE_COLOR__
 
     invoke-direct {v1, v2}, Landroid/graphics/drawable/ColorDrawable;-><init>(I)V
 

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -1,0 +1,464 @@
+.class public final Lradiant/SwipeToQueue;
+.super Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;
+.source "SwipeToQueue.smali"
+
+
+# static fields
+.field private static final installed:Ljava/util/WeakHashMap;
+
+
+# instance fields
+.field private final background:Landroid/graphics/drawable/ColorDrawable;
+
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+.field private final icon:Landroid/graphics/drawable/Drawable;
+
+.field private pendingPosition:I
+
+.field private pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+# direct methods
+.method static constructor <clinit>()V
+    .locals 1
+
+    new-instance v0, Ljava/util/WeakHashMap;
+
+    invoke-direct {v0}, Ljava/util/WeakHashMap;-><init>()V
+
+    sput-object v0, Lradiant/SwipeToQueue;->installed:Ljava/util/WeakHashMap;
+
+    return-void
+.end method
+
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 3
+
+    const/4 v0, 0x0
+
+    # ItemTouchHelper.LEFT
+    const/4 v1, 0x4
+
+    invoke-direct {p0, v0, v1}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;-><init>(II)V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {p2}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    new-instance v1, Landroid/graphics/drawable/ColorDrawable;
+
+    sget v2, Lcom/aspiro/wamp/R$color;->green:I
+
+    invoke-virtual {v0, v2}, Landroid/content/Context;->getColor(I)I
+
+    move-result v2
+
+    invoke-direct {v1, v2}, Landroid/graphics/drawable/ColorDrawable;-><init>(I)V
+
+    iput-object v1, p0, Lradiant/SwipeToQueue;->background:Landroid/graphics/drawable/ColorDrawable;
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    if-eqz v0, :store_icon
+
+    invoke-virtual {v0}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    const/4 v1, -0x1
+
+    invoke-virtual {v0, v1}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_icon
+    iput-object v0, p0, Lradiant/SwipeToQueue;->icon:Landroid/graphics/drawable/Drawable;
+
+    return-void
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 4
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    sget-object v0, Lradiant/SwipeToQueue;->installed:Ljava/util/WeakHashMap;
+
+    invoke-virtual {v0, p1}, Ljava/util/WeakHashMap;->containsKey(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-nez v1, :done
+
+    sget-object v1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
+
+    invoke-virtual {v0, p1, v1}, Ljava/util/WeakHashMap;->put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+
+    new-instance v0, Lradiant/SwipeToQueue;
+
+    invoke-direct {v0, p0, p1}, Lradiant/SwipeToQueue;-><init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+
+    new-instance v1, Landroidx/recyclerview/widget/ItemTouchHelper;
+
+    invoke-direct {v1, v0}, Landroidx/recyclerview/widget/ItemTouchHelper;-><init>(Landroidx/recyclerview/widget/ItemTouchHelper$Callback;)V
+
+    invoke-virtual {v1, p1}, Landroidx/recyclerview/widget/ItemTouchHelper;->attachToRecyclerView(Landroidx/recyclerview/widget/RecyclerView;)V
+
+    :done
+    return-void
+.end method
+
+# virtual methods
+.method public getSwipeDirs(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)I
+    .locals 4
+
+    iget-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-nez v0, :not_swipeable
+
+    instance-of v0, p2, Ln8/d;
+
+    if-eqz v0, :not_swipeable
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result v0
+
+    const/4 v1, -0x1
+
+    if-ne v0, v1, :has_position
+
+    const/4 v0, 0x0
+
+    return v0
+
+    :has_position
+    check-cast p2, Ln8/d;
+
+    iget-object v1, p2, Ln8/d;->f:Lcom/aspiro/wamp/model/MediaItem;
+
+    instance-of v2, v1, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v2, :not_swipeable
+
+    iget-object v2, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v2
+
+    check-cast v2, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+
+    if-eqz v2, :not_swipeable
+
+    check-cast v1, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    invoke-virtual {v2, v0, v1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
+
+    move-result v0
+
+    if-eqz v0, :not_swipeable
+
+    const/4 v0, 0x4
+
+    return v0
+
+    :not_swipeable
+    const/4 v0, 0x0
+
+    return v0
+.end method
+
+.method public onChildDraw(Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FFIZ)V
+    .locals 12
+
+    invoke-super/range {p0 .. p7}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;->onChildDraw(Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FFIZ)V
+
+    move/from16 v10, p6
+
+    move/from16 v11, p4
+
+    const/4 v0, 0x1
+
+    if-ne v10, v0, :done
+
+    const/4 v0, 0x0
+
+    int-to-float v0, v0
+
+    cmpg-float v0, v11, v0
+
+    if-gez v0, :not_left
+
+    goto :clear_active
+
+    :not_left
+
+    if-eqz p7, :done
+
+    const/4 v0, 0x0
+
+    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    goto :done
+
+    :clear_active
+
+    iget-object v0, p3, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->itemView:Landroid/view/View;
+
+    invoke-virtual {v0}, Landroid/view/View;->getRight()I
+
+    move-result v1
+
+    float-to-int v2, v11
+
+    add-int/2addr v2, v1
+
+    invoke-virtual {v0}, Landroid/view/View;->getTop()I
+
+    move-result v3
+
+    invoke-virtual {v0}, Landroid/view/View;->getBottom()I
+
+    move-result v4
+
+    sub-int v5, v1, v2
+
+    if-lez v5, :done
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->background:Landroid/graphics/drawable/ColorDrawable;
+
+    invoke-virtual {v6, v2, v3, v1, v4}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
+
+    invoke-virtual {v0}, Landroid/view/View;->getWidth()I
+
+    move-result v7
+
+    if-eqz p7, :draw_alpha
+
+    # 30% threshold
+    mul-int/lit8 v8, v7, 0x3
+
+    div-int/lit8 v8, v8, 0xa
+
+    if-lt v5, v8, :disarm
+
+    const/4 v8, 0x1
+
+    invoke-virtual {p3}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result v8
+
+    const/4 v9, -0x1
+
+    if-ne v8, v9, :resolve_action
+
+    goto :draw_alpha
+
+    :resolve_action
+    move-object v9, p3
+
+    check-cast v9, Ln8/d;
+
+    iget-object v10, v9, Ln8/d;->f:Lcom/aspiro/wamp/model/MediaItem;
+
+    instance-of v11, v10, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v11, :draw_alpha
+
+    check-cast v10, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    iput v8, p0, Lradiant/SwipeToQueue;->pendingPosition:I
+
+    iput-object v10, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    goto :draw_alpha
+
+    :disarm
+    const/4 v8, 0x0
+
+    iput-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    goto :draw_alpha
+
+    :draw_alpha
+    if-lez v7, :draw_background
+
+    const/16 v8, 0xf8
+
+    mul-int/2addr v8, v5
+
+    div-int/2addr v8, v7
+
+    const/16 v9, 0x1f
+
+    invoke-static {v8, v9}, Ljava/lang/Math;->min(II)I
+
+    move-result v8
+
+    add-int/lit16 v8, v8, 0xe0
+
+    invoke-virtual {v6, v8}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
+
+    :draw_background
+    invoke-virtual {v6, p1}, Landroid/graphics/drawable/ColorDrawable;->draw(Landroid/graphics/Canvas;)V
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->icon:Landroid/graphics/drawable/Drawable;
+
+    if-eqz v6, :done
+
+    invoke-virtual {v6}, Landroid/graphics/drawable/Drawable;->getIntrinsicWidth()I
+
+    move-result v7
+
+    invoke-virtual {v6}, Landroid/graphics/drawable/Drawable;->getIntrinsicHeight()I
+
+    move-result v8
+
+    if-lez v7, :done
+
+    if-lez v8, :done
+
+    # center icon until fixed inset
+    sub-int v9, v4, v3
+
+    sub-int/2addr v9, v8
+
+    div-int/lit8 v9, v9, 0x2
+
+    sub-int v10, v1, v9
+
+    sub-int v11, v10, v7
+
+    add-int v10, v5, v7
+
+    div-int/lit8 v10, v10, 0x2
+
+    sub-int v10, v1, v10
+
+    invoke-static {v10, v11}, Ljava/lang/Math;->max(II)I
+
+    move-result v10
+
+    add-int v11, v10, v7
+
+    invoke-virtual {p1}, Landroid/graphics/Canvas;->save()I
+
+    move-result v7
+
+    invoke-virtual {p1, v2, v3, v1, v4}, Landroid/graphics/Canvas;->clipRect(IIII)Z
+
+    add-int v2, v3, v9
+
+    add-int v5, v2, v8
+
+    invoke-virtual {v6, v10, v2, v11, v5}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
+
+    const/16 v8, 0xff
+
+    invoke-virtual {v6, v8}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
+
+    invoke-virtual {v6, p1}, Landroid/graphics/drawable/Drawable;->draw(Landroid/graphics/Canvas;)V
+
+    invoke-virtual {p1, v7}, Landroid/graphics/Canvas;->restoreToCount(I)V
+
+    :done
+    return-void
+.end method
+
+.method public onMove(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Z
+    .locals 0
+
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public getSwipeEscapeVelocity(F)F
+    .locals 1
+
+    # Float.MAX_VALUE
+    const v0, 0x7f7fffff
+
+    return v0
+.end method
+
+.method public getSwipeThreshold(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)F
+    .locals 1
+
+    # 2.0f
+    const/high16 v0, 0x40000000
+
+    return v0
+.end method
+
+.method public onSelectedChanged(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V
+    .locals 3
+
+    const/4 v0, 0x1
+
+    if-ne p2, v0, :release
+
+    if-eqz p1, :dispatch
+
+    const/4 v0, 0x0
+
+    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    goto :dispatch
+
+    :release
+    if-nez p2, :dispatch
+
+    iget v0, p0, Lradiant/SwipeToQueue;->pendingPosition:I
+
+    iget-object v1, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    const/4 v2, 0x0
+
+    iput-object v2, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v1, :dispatch
+
+    iget-object v2, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v2
+
+    check-cast v2, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+
+    if-eqz v2, :dispatch
+
+    invoke-virtual {v2, v0, v1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
+
+    :dispatch
+    invoke-super {p0, p1, p2}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;->onSelectedChanged(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V
+
+    return-void
+.end method
+
+.method public onSwiped(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V
+    .locals 1
+
+    # fallback
+    iget-object p1, p1, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->itemView:Landroid/view/View;
+
+    const/4 p2, 0x0
+
+    int-to-float v0, p2
+
+    invoke-virtual {p1, v0}, Landroid/view/View;->setTranslationX(F)V
+
+    return-void
+.end method

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -8,9 +8,13 @@
 
 
 # instance fields
-.field private final background:Landroid/graphics/drawable/ColorDrawable;
+.field private final addBackground:Landroid/graphics/drawable/ColorDrawable;
 
-.field private final icon:Landroid/graphics/drawable/Drawable;
+.field private final addIcon:Landroid/graphics/drawable/Drawable;
+
+.field private final playNextBackground:Landroid/graphics/drawable/ColorDrawable;
+
+.field private final playNextIcon:Landroid/graphics/drawable/Drawable;
 
 .field private pendingRequest:Lradiant/swipe/QueueRequest;
 
@@ -32,12 +36,26 @@
 .end method
 
 .method private constructor <init>(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
-    .locals 3
+    .locals 4
 
     const/4 v0, 0x0
 
-    # ItemTouchHelper.LEFT (0x4) or ItemTouchHelper.RIGHT (0x8)
-    const/16 v1, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    const/4 v1, 0x0
+
+    const/16 v2, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    if-eqz v2, :check_right
+
+    or-int/lit8 v1, v1, 0x4
+
+    :check_right
+    const/16 v2, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    if-eqz v2, :directions_ready
+
+    or-int/lit8 v1, v1, 0x8
+
+    :directions_ready
 
     invoke-direct {p0, v0, v1}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;-><init>(II)V
 
@@ -49,11 +67,19 @@
 
     new-instance v1, Landroid/graphics/drawable/ColorDrawable;
 
-    const v2, __RL_SWIPE_TO_QUEUE_COLOR__
+    const v2, __RL_SWIPE_TO_QUEUE_ADD_COLOR__
 
     invoke-direct {v1, v2}, Landroid/graphics/drawable/ColorDrawable;-><init>(I)V
 
-    iput-object v1, p0, Lradiant/SwipeToQueue;->background:Landroid/graphics/drawable/ColorDrawable;
+    iput-object v1, p0, Lradiant/SwipeToQueue;->addBackground:Landroid/graphics/drawable/ColorDrawable;
+
+    new-instance v1, Landroid/graphics/drawable/ColorDrawable;
+
+    const v2, __RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR__
+
+    invoke-direct {v1, v2}, Landroid/graphics/drawable/ColorDrawable;-><init>(I)V
+
+    iput-object v1, p0, Lradiant/SwipeToQueue;->playNextBackground:Landroid/graphics/drawable/ColorDrawable;
 
     sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
 
@@ -72,7 +98,30 @@
     invoke-virtual {v0, v1}, Landroid/graphics/drawable/Drawable;->setTint(I)V
 
     :store_icon
-    iput-object v0, p0, Lradiant/SwipeToQueue;->icon:Landroid/graphics/drawable/Drawable;
+    iput-object v0, p0, Lradiant/SwipeToQueue;->addIcon:Landroid/graphics/drawable/Drawable;
+
+    invoke-virtual {p1}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_play_next:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    if-eqz v0, :store_play_next_icon
+
+    invoke-virtual {v0}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    const/4 v1, -0x1
+
+    invoke-virtual {v0, v1}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_play_next_icon
+    iput-object v0, p0, Lradiant/SwipeToQueue;->playNextIcon:Landroid/graphics/drawable/Drawable;
 
     return-void
 .end method
@@ -135,7 +184,7 @@
 .end method
 
 .method public getSwipeDirs(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)I
-    .locals 2
+    .locals 3
 
     iget-object v0, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
@@ -149,7 +198,22 @@
 
     if-eqz v0, :not_swipeable
 
-    const/16 v0, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    const/4 v0, 0x0
+
+    const/16 v1, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    if-eqz v1, :check_right
+
+    or-int/lit8 v0, v0, 0x4
+
+    :check_right
+    const/16 v1, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    if-eqz v1, :directions_ready
+
+    or-int/lit8 v0, v0, 0x8
+
+    :directions_ready
 
     return v0
 
@@ -176,22 +240,26 @@
 
     int-to-float v0, v0
 
-    const/16 v8, __RL_SWIPE_TO_QUEUE_DIRECTION__
-
-    const/4 v9, 0x4
-
-    if-ne v8, v9, :expect_right
-
     cmpg-float v8, v11, v0
 
-    if-gez v8, :wrong_direction
+    if-ltz v8, :left_action
 
-    goto :clear_active
-
-    :expect_right
     cmpl-float v8, v11, v0
 
-    if-lez v8, :wrong_direction
+    if-gtz v8, :right_action
+
+    goto :wrong_direction
+
+    :left_action
+    const/16 v8, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    goto :action_ready
+
+    :right_action
+    const/16 v8, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    :action_ready
+    if-eqz v8, :wrong_direction
 
     goto :clear_active
 
@@ -217,11 +285,13 @@
 
     move-result v4
 
-    const/16 v8, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    const/4 v8, 0x0
 
-    const/4 v9, 0x4
+    int-to-float v8, v8
 
-    if-ne v8, v9, :right_bounds
+    cmpg-float v8, v11, v8
+
+    if-gez v8, :right_bounds
 
     invoke-virtual {v0}, Landroid/view/View;->getRight()I
 
@@ -248,7 +318,34 @@
 
     if-lez v5, :done
 
-    iget-object v6, p0, Lradiant/SwipeToQueue;->background:Landroid/graphics/drawable/ColorDrawable;
+    const/4 v8, 0x0
+
+    int-to-float v8, v8
+
+    cmpg-float v8, v11, v8
+
+    if-ltz v8, :draw_left_background
+
+    const/16 v8, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    goto :background_action_ready
+
+    :draw_left_background
+    const/16 v8, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    :background_action_ready
+    const/4 v9, 0x1
+
+    if-ne v8, v9, :add_background
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->playNextBackground:Landroid/graphics/drawable/ColorDrawable;
+
+    goto :background_ready
+
+    :add_background
+    iget-object v6, p0, Lradiant/SwipeToQueue;->addBackground:Landroid/graphics/drawable/ColorDrawable;
+
+    :background_ready
 
     invoke-virtual {v6, v2, v3, v1, v4}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
 
@@ -279,6 +376,24 @@
     move-result-object v10
 
     if-eqz v10, :draw_alpha
+
+    const/4 v9, 0x0
+
+    int-to-float v9, v9
+
+    cmpg-float v9, v11, v9
+
+    if-ltz v9, :stamp_left_action
+
+    const/16 v9, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    goto :stamp_action
+
+    :stamp_left_action
+    const/16 v9, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    :stamp_action
+    iput v9, v10, Lradiant/swipe/QueueRequest;->action:I
 
     iput-object v10, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
@@ -334,7 +449,34 @@
     :draw_background
     invoke-virtual {v6, p1}, Landroid/graphics/drawable/ColorDrawable;->draw(Landroid/graphics/Canvas;)V
 
-    iget-object v6, p0, Lradiant/SwipeToQueue;->icon:Landroid/graphics/drawable/Drawable;
+    const/4 v8, 0x0
+
+    int-to-float v8, v8
+
+    cmpg-float v8, v11, v8
+
+    if-ltz v8, :draw_left_icon
+
+    const/16 v8, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    goto :icon_action_ready
+
+    :draw_left_icon
+    const/16 v8, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    :icon_action_ready
+    const/4 v9, 0x1
+
+    if-ne v8, v9, :draw_add_icon
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->playNextIcon:Landroid/graphics/drawable/Drawable;
+
+    goto :icon_ready
+
+    :draw_add_icon
+    iget-object v6, p0, Lradiant/SwipeToQueue;->addIcon:Landroid/graphics/drawable/Drawable;
+
+    :icon_ready
 
     if-eqz v6, :done
 
@@ -357,11 +499,13 @@
 
     div-int/lit8 v9, v9, 0x2
 
-    const/16 v10, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    const/4 v10, 0x0
 
-    const/4 v11, 0x4
+    int-to-float v10, v10
 
-    if-ne v10, v11, :right_icon
+    cmpg-float v10, v11, v10
+
+    if-gez v10, :right_icon
 
     sub-int v10, v1, v9
 

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -10,13 +10,13 @@
 # instance fields
 .field private final background:Landroid/graphics/drawable/ColorDrawable;
 
-.field private final fragment:Ljava/lang/ref/WeakReference;
-
 .field private final icon:Landroid/graphics/drawable/Drawable;
 
-.field private pendingPosition:I
+.field private pendingRequest:Lradiant/swipe/QueueRequest;
 
-.field private pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+.field private releaseAllowed:Z
+
+.field private final resolver:Lradiant/swipe/QueueRowResolver;
 
 # direct methods
 .method static constructor <clinit>()V
@@ -31,7 +31,7 @@
     return-void
 .end method
 
-.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+.method private constructor <init>(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
     .locals 3
 
     const/4 v0, 0x0
@@ -41,13 +41,9 @@
 
     invoke-direct {p0, v0, v1}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;-><init>(II)V
 
-    new-instance v0, Ljava/lang/ref/WeakReference;
+    iput-object p2, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
 
-    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
-
-    iput-object v0, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
-
-    invoke-virtual {p2}, Landroid/view/View;->getContext()Landroid/content/Context;
+    invoke-virtual {p1}, Landroid/view/View;->getContext()Landroid/content/Context;
 
     move-result-object v0
 
@@ -85,7 +81,7 @@
     return-void
 .end method
 
-.method public static install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+.method public static install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
     .locals 4
 
     if-eqz p0, :done
@@ -94,7 +90,7 @@
 
     sget-object v0, Lradiant/SwipeToQueue;->installed:Ljava/util/WeakHashMap;
 
-    invoke-virtual {v0, p1}, Ljava/util/WeakHashMap;->containsKey(Ljava/lang/Object;)Z
+    invoke-virtual {v0, p0}, Ljava/util/WeakHashMap;->containsKey(Ljava/lang/Object;)Z
 
     move-result v1
 
@@ -102,17 +98,32 @@
 
     sget-object v1, Ljava/lang/Boolean;->TRUE:Ljava/lang/Boolean;
 
-    invoke-virtual {v0, p1, v1}, Ljava/util/WeakHashMap;->put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+    invoke-virtual {v0, p0, v1}, Ljava/util/WeakHashMap;->put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 
     new-instance v0, Lradiant/SwipeToQueue;
 
-    invoke-direct {v0, p0, p1}, Lradiant/SwipeToQueue;-><init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    invoke-direct {v0, p0, p1}, Lradiant/SwipeToQueue;-><init>(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
 
     new-instance v1, Landroidx/recyclerview/widget/ItemTouchHelper;
 
     invoke-direct {v1, v0}, Landroidx/recyclerview/widget/ItemTouchHelper;-><init>(Landroidx/recyclerview/widget/ItemTouchHelper$Callback;)V
 
-    invoke-virtual {v1, p1}, Landroidx/recyclerview/widget/ItemTouchHelper;->attachToRecyclerView(Landroidx/recyclerview/widget/RecyclerView;)V
+    invoke-virtual {v1, p0}, Landroidx/recyclerview/widget/ItemTouchHelper;->attachToRecyclerView(Landroidx/recyclerview/widget/RecyclerView;)V
+
+    :done
+    return-void
+.end method
+
+.method public static setReleaseAllowed(Landroidx/recyclerview/widget/ItemTouchHelper$Callback;Z)V
+    .locals 1
+
+    instance-of v0, p0, Lradiant/SwipeToQueue;
+
+    if-eqz v0, :done
+
+    check-cast p0, Lradiant/SwipeToQueue;
+
+    iput-boolean p1, p0, Lradiant/SwipeToQueue;->releaseAllowed:Z
 
     :done
     return-void
@@ -120,52 +131,17 @@
 
 # virtual methods
 .method public getSwipeDirs(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)I
-    .locals 4
+    .locals 2
 
-    iget-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iget-object v0, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     if-nez v0, :not_swipeable
 
-    instance-of v0, p2, Ln8/d;
+    iget-object v0, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
 
-    if-eqz v0, :not_swipeable
+    invoke-interface {v0, p1, p2}, Lradiant/swipe/QueueRowResolver;->resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
 
-    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
-
-    move-result v0
-
-    const/4 v1, -0x1
-
-    if-ne v0, v1, :has_position
-
-    const/4 v0, 0x0
-
-    return v0
-
-    :has_position
-    check-cast p2, Ln8/d;
-
-    iget-object v1, p2, Ln8/d;->f:Lcom/aspiro/wamp/model/MediaItem;
-
-    instance-of v2, v1, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    if-eqz v2, :not_swipeable
-
-    iget-object v2, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
-
-    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
-
-    move-result-object v2
-
-    check-cast v2, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
-
-    if-eqz v2, :not_swipeable
-
-    check-cast v1, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    invoke-virtual {v2, v0, v1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
-
-    move-result v0
+    move-result-object v0
 
     if-eqz v0, :not_swipeable
 
@@ -221,7 +197,7 @@
 
     const/4 v0, 0x0
 
-    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     goto :done
 
@@ -286,37 +262,19 @@
 
     if-lt v5, v8, :disarm
 
-    invoke-virtual {p3}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+    iget-object v8, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
 
-    move-result v8
+    iget-object v10, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
-    # RecyclerView.NO_POSITION.
-    const/4 v9, -0x1
+    if-nez v10, :draw_alpha
 
-    if-ne v8, v9, :resolve_action
+    invoke-interface {v8, p2, p3}, Lradiant/swipe/QueueRowResolver;->resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
 
-    goto :draw_alpha
+    move-result-object v10
 
-    :resolve_action
-    move-object v9, p3
+    if-eqz v10, :draw_alpha
 
-    check-cast v9, Ln8/d;
-
-    iget-object v10, v9, Ln8/d;->f:Lcom/aspiro/wamp/model/MediaItem;
-
-    instance-of v11, v10, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    if-eqz v11, :draw_alpha
-
-    check-cast v10, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    iput v8, p0, Lradiant/SwipeToQueue;->pendingPosition:I
-
-    iget-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    iput-object v10, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    if-nez v8, :draw_alpha
+    iput-object v10, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     # HapticFeedbackConstants.CLOCK_TICK
     const/4 v8, 0x4
@@ -326,7 +284,7 @@
     goto :draw_alpha
 
     :disarm
-    iget-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iget-object v8, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     if-eqz v8, :clear_pending
 
@@ -338,7 +296,7 @@
     :clear_pending
     const/4 v8, 0x0
 
-    iput-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iput-object v8, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     goto :draw_alpha
 
@@ -491,34 +449,36 @@
 
     const/4 v0, 0x0
 
-    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iput-object v0, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
 
     goto :dispatch
 
     :release
     if-nez p2, :dispatch
 
-    iget v0, p0, Lradiant/SwipeToQueue;->pendingPosition:I
-
-    iget-object v1, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iget-boolean v0, p0, Lradiant/SwipeToQueue;->releaseAllowed:Z
 
     const/4 v2, 0x0
 
-    iput-object v2, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+    iput-boolean v2, p0, Lradiant/SwipeToQueue;->releaseAllowed:Z
+
+    iget-object v1, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
+
+    iput-object v2, p0, Lradiant/SwipeToQueue;->pendingRequest:Lradiant/swipe/QueueRequest;
+
+    if-eqz v0, :dispatch
 
     if-eqz v1, :dispatch
 
-    iget-object v2, p0, Lradiant/SwipeToQueue;->fragment:Ljava/lang/ref/WeakReference;
+    iget-object v2, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
 
-    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    invoke-interface {v2, v1}, Lradiant/swipe/QueueRowResolver;->isValid(Lradiant/swipe/QueueRequest;)Z
 
-    move-result-object v2
+    move-result v0
 
-    check-cast v2, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+    if-eqz v0, :dispatch
 
-    if-eqz v2, :dispatch
-
-    invoke-virtual {v2, v0, v1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
+    invoke-interface {v2, v1}, Lradiant/swipe/QueueRowResolver;->execute(Lradiant/swipe/QueueRequest;)V
 
     :dispatch
     invoke-super {p0, p1, p2}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;->onSelectedChanged(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -12,6 +12,10 @@
 
 .field private final addIcon:Landroid/graphics/drawable/Drawable;
 
+.field private final addToPlaylistBackground:Landroid/graphics/drawable/ColorDrawable;
+
+.field private final addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
+
 .field private final playNextBackground:Landroid/graphics/drawable/ColorDrawable;
 
 .field private final playNextIcon:Landroid/graphics/drawable/Drawable;
@@ -81,6 +85,14 @@
 
     iput-object v1, p0, Lradiant/SwipeToQueue;->playNextBackground:Landroid/graphics/drawable/ColorDrawable;
 
+    new-instance v1, Landroid/graphics/drawable/ColorDrawable;
+
+    const v2, __RL_SWIPE_TO_QUEUE_ADD_TO_PLAYLIST_COLOR__
+
+    invoke-direct {v1, v2}, Landroid/graphics/drawable/ColorDrawable;-><init>(I)V
+
+    iput-object v1, p0, Lradiant/SwipeToQueue;->addToPlaylistBackground:Landroid/graphics/drawable/ColorDrawable;
+
     sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
 
     invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
@@ -122,6 +134,29 @@
 
     :store_play_next_icon
     iput-object v0, p0, Lradiant/SwipeToQueue;->playNextIcon:Landroid/graphics/drawable/Drawable;
+
+    invoke-virtual {p1}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_playlist:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    if-eqz v0, :store_add_to_playlist_icon
+
+    invoke-virtual {v0}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v0
+
+    const/4 v1, -0x1
+
+    invoke-virtual {v0, v1}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_add_to_playlist_icon
+    iput-object v0, p0, Lradiant/SwipeToQueue;->addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
 
     return-void
 .end method
@@ -343,6 +378,15 @@
     goto :background_ready
 
     :add_background
+    const/4 v9, 0x3
+
+    if-ne v8, v9, :add_to_queue_background
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->addToPlaylistBackground:Landroid/graphics/drawable/ColorDrawable;
+
+    goto :background_ready
+
+    :add_to_queue_background
     iget-object v6, p0, Lradiant/SwipeToQueue;->addBackground:Landroid/graphics/drawable/ColorDrawable;
 
     :background_ready
@@ -474,6 +518,15 @@
     goto :icon_ready
 
     :draw_add_icon
+    const/4 v9, 0x3
+
+    if-ne v8, v9, :draw_add_to_queue_icon
+
+    iget-object v6, p0, Lradiant/SwipeToQueue;->addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
+
+    goto :icon_ready
+
+    :draw_add_to_queue_icon
     iget-object v6, p0, Lradiant/SwipeToQueue;->addIcon:Landroid/graphics/drawable/Drawable;
 
     :icon_ready

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -246,19 +246,19 @@
 
     if-eqz p7, :draw_alpha
 
-    # 30% threshold
+    # row width * 3
     mul-int/lit8 v8, v7, 0x3
 
+    # / 10 = 30% of row width (30% threshold)
     div-int/lit8 v8, v8, 0xa
 
     if-lt v5, v8, :disarm
-
-    const/4 v8, 0x1
 
     invoke-virtual {p3}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
 
     move-result v8
 
+    # RecyclerView.NO_POSITION.
     const/4 v9, -0x1
 
     if-ne v8, v9, :resolve_action
@@ -280,11 +280,30 @@
 
     iput v8, p0, Lradiant/SwipeToQueue;->pendingPosition:I
 
+    iget-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
     iput-object v10, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-nez v8, :draw_alpha
+
+    # HapticFeedbackConstants.CLOCK_TICK
+    const/4 v8, 0x4
+
+    invoke-virtual {v0, v8}, Landroid/view/View;->performHapticFeedback(I)Z
 
     goto :draw_alpha
 
     :disarm
+    iget-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v8, :clear_pending
+
+    # HapticFeedbackConstants.CLOCK_TICK
+    const/4 v8, 0x4
+
+    invoke-virtual {v0, v8}, Landroid/view/View;->performHapticFeedback(I)Z
+
+    :clear_pending
     const/4 v8, 0x0
 
     iput-object v8, p0, Lradiant/SwipeToQueue;->pendingTrack:Lcom/aspiro/wamp/model/FavoriteTrack;
@@ -294,19 +313,23 @@
     :draw_alpha
     if-lez v7, :draw_background
 
-    const/16 v8, 0xf8
+    mul-int/lit8 v8, v7, 0x3
 
-    mul-int/2addr v8, v5
+    div-int/lit8 v8, v8, 0xa
 
-    div-int/2addr v8, v7
+    const/16 v9, 0x40
 
-    const/16 v9, 0x1f
+    mul-int/2addr v9, v5
 
-    invoke-static {v8, v9}, Ljava/lang/Math;->min(II)I
+    div-int/2addr v9, v8
+
+    const/16 v8, 0x40
+
+    invoke-static {v9, v8}, Ljava/lang/Math;->min(II)I
 
     move-result v8
 
-    add-int/lit16 v8, v8, 0xe0
+    add-int/lit16 v8, v8, 0xbf
 
     invoke-virtual {v6, v8}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
 

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -260,6 +260,8 @@
     # / 10 = 30% of row width (30% threshold)
     div-int/lit8 v8, v8, 0xa
 
+    if-lez v8, :disarm
+
     if-lt v5, v8, :disarm
 
     iget-object v8, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
@@ -306,6 +308,8 @@
     mul-int/lit8 v8, v7, 0x3
 
     div-int/lit8 v8, v8, 0xa
+
+    if-lez v8, :draw_background
 
     const/16 v9, 0x40
 
@@ -470,15 +474,9 @@
 
     if-eqz v1, :dispatch
 
-    iget-object v2, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
+    iget-object v0, p0, Lradiant/SwipeToQueue;->resolver:Lradiant/swipe/QueueRowResolver;
 
-    invoke-interface {v2, v1}, Lradiant/swipe/QueueRowResolver;->isValid(Lradiant/swipe/QueueRequest;)Z
-
-    move-result v0
-
-    if-eqz v0, :dispatch
-
-    invoke-interface {v2, v1}, Lradiant/swipe/QueueRowResolver;->execute(Lradiant/swipe/QueueRequest;)V
+    invoke-interface {v0, v1}, Lradiant/swipe/QueueRowResolver;->execute(Lradiant/swipe/QueueRequest;)V
 
     :dispatch
     invoke-super {p0, p1, p2}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;->onSelectedChanged(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -36,8 +36,8 @@
 
     const/4 v0, 0x0
 
-    # ItemTouchHelper.LEFT
-    const/4 v1, 0x4
+    # ItemTouchHelper.LEFT (0x4) or ItemTouchHelper.RIGHT (0x8)
+    const/16 v1, __RL_SWIPE_TO_QUEUE_DIRECTION__
 
     invoke-direct {p0, v0, v1}, Landroidx/recyclerview/widget/ItemTouchHelper$SimpleCallback;-><init>(II)V
 
@@ -169,7 +169,7 @@
 
     if-eqz v0, :not_swipeable
 
-    const/4 v0, 0x4
+    const/16 v0, __RL_SWIPE_TO_QUEUE_DIRECTION__
 
     return v0
 
@@ -196,13 +196,26 @@
 
     int-to-float v0, v0
 
-    cmpg-float v0, v11, v0
+    const/16 v8, __RL_SWIPE_TO_QUEUE_DIRECTION__
 
-    if-gez v0, :not_left
+    const/4 v9, 0x4
+
+    if-ne v8, v9, :expect_right
+
+    cmpg-float v8, v11, v0
+
+    if-gez v8, :wrong_direction
 
     goto :clear_active
 
-    :not_left
+    :expect_right
+    cmpl-float v8, v11, v0
+
+    if-lez v8, :wrong_direction
+
+    goto :clear_active
+
+    :wrong_direction
 
     if-eqz p7, :done
 
@@ -216,6 +229,20 @@
 
     iget-object v0, p3, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->itemView:Landroid/view/View;
 
+    invoke-virtual {v0}, Landroid/view/View;->getTop()I
+
+    move-result v3
+
+    invoke-virtual {v0}, Landroid/view/View;->getBottom()I
+
+    move-result v4
+
+    const/16 v8, __RL_SWIPE_TO_QUEUE_DIRECTION__
+
+    const/4 v9, 0x4
+
+    if-ne v8, v9, :right_bounds
+
     invoke-virtual {v0}, Landroid/view/View;->getRight()I
 
     move-result v1
@@ -224,13 +251,18 @@
 
     add-int/2addr v2, v1
 
-    invoke-virtual {v0}, Landroid/view/View;->getTop()I
+    goto :bounds_ready
 
-    move-result v3
+    :right_bounds
+    invoke-virtual {v0}, Landroid/view/View;->getLeft()I
 
-    invoke-virtual {v0}, Landroid/view/View;->getBottom()I
+    move-result v2
 
-    move-result v4
+    float-to-int v1, v11
+
+    add-int/2addr v1, v2
+
+    :bounds_ready
 
     sub-int v5, v1, v2
 
@@ -359,6 +391,12 @@
 
     div-int/lit8 v9, v9, 0x2
 
+    const/16 v10, __RL_SWIPE_TO_QUEUE_DIRECTION__
+
+    const/4 v11, 0x4
+
+    if-ne v10, v11, :right_icon
+
     sub-int v10, v1, v9
 
     sub-int v11, v10, v7
@@ -372,6 +410,23 @@
     invoke-static {v10, v11}, Ljava/lang/Math;->max(II)I
 
     move-result v10
+
+    goto :icon_positioned
+
+    :right_icon
+    add-int v10, v2, v9
+
+    sub-int v11, v5, v7
+
+    div-int/lit8 v11, v11, 0x2
+
+    add-int/2addr v11, v2
+
+    invoke-static {v11, v10}, Ljava/lang/Math;->min(II)I
+
+    move-result v10
+
+    :icon_positioned
 
     add-int v11, v10, v7
 

--- a/patches/extension/radiant/SwipeToQueue.smali
+++ b/patches/extension/radiant/SwipeToQueue.smali
@@ -130,6 +130,14 @@
 .end method
 
 # virtual methods
+.method public getAnimationDuration(Landroidx/recyclerview/widget/RecyclerView;IFF)J
+    .locals 2
+
+    const-wide/16 v0, 0x50
+
+    return-wide v0
+.end method
+
 .method public getSwipeDirs(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)I
     .locals 2
 

--- a/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
+++ b/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
@@ -1,0 +1,183 @@
+.class public final Lradiant/swipe/AlbumItemQueueAction;
+.super Ljava/lang/Object;
+.source "AlbumItemQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lu5/b$a$a;
+
+.field private context:Landroid/content/Context;
+
+.field private final mediaItemId:I
+
+.field private final moduleId:Ljava/lang/String;
+
+
+# direct methods
+.method public constructor <init>(Lu5/b$a;)V
+    .locals 2
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iget-object v0, p1, Lu5/b$a;->a:Lu5/b$a$a;
+
+    iput-object v0, p0, Lradiant/swipe/AlbumItemQueueAction;->callback:Lu5/b$a$a;
+
+    iget-object v0, p1, Lu5/b$a;->c:Lu5/b$a$b;
+
+    iget v1, v0, Lu5/b$a$b;->r:I
+
+    iput v1, p0, Lradiant/swipe/AlbumItemQueueAction;->mediaItemId:I
+
+    iget-object v0, v0, Lu5/b$a$b;->s:Ljava/lang/String;
+
+    iput-object v0, p0, Lradiant/swipe/AlbumItemQueueAction;->moduleId:Ljava/lang/String;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 10
+
+    iget-object v0, p0, Lradiant/swipe/AlbumItemQueueAction;->callback:Lu5/b$a$a;
+
+    iget v1, p0, Lradiant/swipe/AlbumItemQueueAction;->mediaItemId:I
+
+    iget-object v2, p0, Lradiant/swipe/AlbumItemQueueAction;->moduleId:Ljava/lang/String;
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v3
+
+    if-nez v3, :active_queue
+
+    invoke-interface {v0, v1, v2}, Lu5/b$a$a;->g(ILjava/lang/String;)V
+
+    goto :done
+
+    :active_queue
+    iget-object v3, p0, Lradiant/swipe/AlbumItemQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v3, :done
+
+    instance-of v4, v0, Lu5/g;
+
+    if-eqz v4, :done
+
+    check-cast v0, Lu5/g;
+
+    invoke-virtual {v0, v2}, Lk5/f;->l(Ljava/lang/String;)Lcom/aspiro/wamp/dynamicpages/data/model/Module;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lcom/aspiro/wamp/dynamicpages/data/model/collection/AlbumItemCollectionModule;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lcom/aspiro/wamp/dynamicpages/data/model/collection/AlbumItemCollectionModule;
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/dynamicpages/data/model/collection/AlbumItemCollectionModule;->getMediaItemParents()Ljava/util/List;
+
+    move-result-object v5
+
+    invoke-interface {v5}, Ljava/lang/Iterable;->iterator()Ljava/util/Iterator;
+
+    move-result-object v5
+
+    :find_item
+    invoke-interface {v5}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v6
+
+    if-eqz v6, :done
+
+    invoke-interface {v5}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v6
+
+    check-cast v6, Lcom/aspiro/wamp/model/MediaItemParent;
+
+    invoke-virtual {v6}, Lcom/aspiro/wamp/model/MediaItemParent;->getMediaItem()Lcom/aspiro/wamp/model/MediaItem;
+
+    move-result-object v7
+
+    if-eqz v7, :find_item
+
+    invoke-virtual {v7}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v8
+
+    if-ne v8, v1, :find_item
+
+    instance-of v8, v7, Lcom/aspiro/wamp/model/Track;
+
+    if-eqz v8, :done
+
+    check-cast v7, Lcom/aspiro/wamp/model/Track;
+
+    iget-object v8, v0, Lu5/g;->h:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    invoke-interface {v8, v7}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/MediaItem;)Lcom/aspiro/wamp/model/Availability$MediaItem;
+
+    move-result-object v8
+
+    invoke-virtual {v8}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+
+    move-result v8
+
+    if-eqz v8, :done
+
+    new-instance v5, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getPageId()Ljava/lang/String;
+
+    move-result-object v6
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getId()Ljava/lang/String;
+
+    move-result-object v8
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getPosition()I
+
+    move-result v9
+
+    invoke-static {v9}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v9
+
+    invoke-direct {v5, v6, v8, v9}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    invoke-virtual {v7}, Lcom/aspiro/wamp/model/MediaItem;->getAlbum()Lcom/aspiro/wamp/model/Album;
+
+    move-result-object v6
+
+    if-eqz v6, :done
+
+    iget-object v8, v0, Lu5/g;->j:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v6, v8}, Lcom/aspiro/wamp/playqueue/source/model/b;->c(Lcom/aspiro/wamp/model/Album;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/AlbumSource;
+
+    move-result-object v6
+
+    invoke-virtual {v6, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v3, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/AlbumItemQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
+++ b/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
@@ -41,7 +41,7 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
+.method public invoke(I)Ljava/lang/Object;
     .locals 10
 
     iget-object v0, p0, Lradiant/swipe/AlbumItemQueueAction;->callback:Lu5/b$a$a;
@@ -166,10 +166,31 @@
 
     invoke-virtual {v6, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    const/4 v8, 0x1
+
+    if-ne p1, v8, :append_track
+
+    invoke-static {v3, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v3, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/AlbumItemQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
+++ b/patches/extension/radiant/swipe/AlbumItemQueueAction.smali
@@ -50,6 +50,10 @@
 
     iget-object v2, p0, Lradiant/swipe/AlbumItemQueueAction;->moduleId:Ljava/lang/String;
 
+    const/4 v3, 0x3
+
+    if-eq p1, v3, :active_queue
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v3
@@ -168,9 +172,18 @@
 
     const/4 v8, 0x1
 
-    if-ne p1, v8, :append_track
+    if-ne p1, v8, :check_add_to_playlist
 
     invoke-static {v3, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_to_playlist
+    const/4 v8, 0x3
+
+    if-ne p1, v8, :append_track
+
+    invoke-static {v3, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
@@ -158,9 +158,18 @@
 
     const/4 v2, 0x1
 
-    if-ne v0, v2, :append
+    if-ne v0, v2, :check_add_to_playlist
 
     invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_to_playlist
+    const/4 v2, 0x3
+
+    if-ne v0, v2, :append
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
@@ -1,0 +1,161 @@
+.class public final Lradiant/swipe/ArtistTrackCreditsQueue;
+.super Ljava/lang/Object;
+.source "ArtistTrackCreditsQueue.smali"
+
+
+# direct methods
+.method public static handle(Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/ArtistTrackCreditsModuleManager;Lradiant/swipe/ArtistTrackCreditsQueueEvent;)V
+    .locals 11
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget-object v0, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->pageId:Ljava/lang/String;
+
+    if-eqz v0, :done
+
+    invoke-virtual {v0}, Ljava/lang/String;->length()I
+
+    move-result v1
+
+    if-lez v1, :done
+
+    iget-object v1, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v1}, Ljava/lang/String;->length()I
+
+    move-result v2
+
+    if-lez v2, :done
+
+    iget-wide v2, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->trackId:J
+
+    const-wide/16 v4, 0x0
+
+    cmp-long v4, v2, v4
+
+    if-lez v4, :done
+
+    invoke-virtual {p0, v1}, Li60/c;->c(Ljava/lang/String;)Lc60/h;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lc60/d;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lc60/d;
+
+    iget-object v5, v4, Lc60/d;->b:Ljava/lang/String;
+
+    invoke-virtual {v1, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    iget-object v1, v4, Lc60/d;->f:Ljava/util/ArrayList;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v1}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v1
+
+    :find_track
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v5
+
+    if-eqz v5, :done
+
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v5
+
+    instance-of v6, v5, Lc60/r$b;
+
+    if-eqz v6, :find_track
+
+    check-cast v5, Lc60/r$b;
+
+    iget-object v5, v5, Lc60/r$b;->a:Lh40/n;
+
+    instance-of v6, v5, Lh40/p;
+
+    if-eqz v6, :find_track
+
+    check-cast v5, Lh40/p;
+
+    iget-wide v6, v5, Lh40/p;->a:J
+
+    cmp-long v6, v6, v2
+
+    if-nez v6, :find_track
+
+    iget-object v1, p0, Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/ArtistTrackCreditsModuleManager;->b:Lcom/tidal/android/dynamicpages/ui/b;
+
+    instance-of v2, v1, Lcom/tidal/android/dynamicpages/ui/c;
+
+    if-eqz v2, :done
+
+    check-cast v1, Lcom/tidal/android/dynamicpages/ui/c;
+
+    iget-object v6, v1, Lcom/tidal/android/dynamicpages/ui/c;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    if-eqz v6, :done
+
+    iget-object v1, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    invoke-static {v5}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v7
+
+    if-eqz v7, :done
+
+    iget-object v2, v4, Lc60/d;->a:Ljava/lang/String;
+
+    if-eqz v2, :done
+
+    new-instance v8, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget v3, v4, Lc60/d;->e:I
+
+    invoke-static {v3}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v3
+
+    invoke-direct {v8, v0, v2, v3}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    iget-wide v2, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->trackId:J
+
+    invoke-static {v2, v3}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v2
+
+    iget-object v3, v4, Lc60/d;->c:Ljava/lang/String;
+
+    iget-object v10, v4, Lc60/d;->g:Ljava/lang/String;
+
+    invoke-static {v10}, Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$a;->a(Ljava/lang/String;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;
+
+    move-result-object v4
+
+    invoke-static {v2, v3, v6, v4}, Lcom/aspiro/wamp/playqueue/source/model/b;->j(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v9
+
+    if-eqz v9, :done
+
+    invoke-virtual {v9, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueue.smali
@@ -154,6 +154,17 @@
 
     invoke-virtual {v9, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    iget v0, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->action:I
+
+    const/4 v2, 0x1
+
+    if-ne v0, v2, :append
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append
     invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
@@ -1,0 +1,95 @@
+.class public final Lradiant/swipe/ArtistTrackCreditsQueueAction;
+.super Ljava/lang/Object;
+.source "ArtistTrackCreditsQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final moduleUuid:Ljava/lang/String;
+
+.field private final pageId:Ljava/lang/String;
+
+.field private final trackId:J
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$e;)V
+    .locals 2
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->callback:Lam0/l;
+
+    iput-object p2, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->moduleUuid:Ljava/lang/String;
+
+    iget-wide v0, p4, Lm40/e$e;->a:J
+
+    iput-wide v0, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 7
+
+    iget-wide v1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v0
+
+    if-nez v0, :active_queue
+
+    new-instance v0, Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/b$a;
+
+    iget-object v3, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v4, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-direct {v0, v1, v2, v3, v4}, Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/b$a;-><init>(JLjava/lang/String;Ljava/lang/String;)V
+
+    goto :emit
+
+    :active_queue
+    new-instance v0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;
+
+    iget-object v1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    iget-object v2, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->moduleUuid:Ljava/lang/String;
+
+    iget-wide v4, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
+
+    invoke-direct/range {v0 .. v5}, Lradiant/swipe/ArtistTrackCreditsQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+
+    :emit
+    iget-object v6, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->callback:Lam0/l;
+
+    invoke-interface {v6, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
@@ -44,6 +44,10 @@
 
     iget-wide v1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
 
+    const/4 v0, 0x3
+
+    if-eq p1, v0, :active_queue
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v0

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueueAction.smali
@@ -39,8 +39,8 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
-    .locals 7
+.method public invoke(I)Ljava/lang/Object;
+    .locals 8
 
     iget-wide v1, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
 
@@ -73,15 +73,29 @@
 
     iget-wide v4, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->trackId:J
 
-    invoke-direct/range {v0 .. v5}, Lradiant/swipe/ArtistTrackCreditsQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+    move v6, p1
+
+    invoke-direct/range {v0 .. v6}, Lradiant/swipe/ArtistTrackCreditsQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;JI)V
 
     :emit
-    iget-object v6, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->callback:Lam0/l;
+    iget-object v7, p0, Lradiant/swipe/ArtistTrackCreditsQueueAction;->callback:Lam0/l;
 
-    invoke-interface {v6, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    invoke-interface {v7, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/ArtistTrackCreditsQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueueEvent.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueueEvent.smali
@@ -1,0 +1,34 @@
+.class public final Lradiant/swipe/ArtistTrackCreditsQueueEvent;
+.super Ljava/lang/Object;
+.source "ArtistTrackCreditsQueueEvent.smali"
+
+# interfaces
+.implements Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/b;
+
+
+# instance fields
+.field public final context:Landroid/content/Context;
+
+.field public final moduleUuid:Ljava/lang/String;
+
+.field public final pageId:Ljava/lang/String;
+
+.field public final trackId:J
+
+
+# direct methods
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->context:Landroid/content/Context;
+
+    iput-object p2, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iput-wide p4, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->trackId:J
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ArtistTrackCreditsQueueEvent.smali
+++ b/patches/extension/radiant/swipe/ArtistTrackCreditsQueueEvent.smali
@@ -7,6 +7,8 @@
 
 
 # instance fields
+.field public final action:I
+
 .field public final context:Landroid/content/Context;
 
 .field public final moduleUuid:Ljava/lang/String;
@@ -17,7 +19,7 @@
 
 
 # direct methods
-.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;JI)V
     .locals 0
 
     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
@@ -29,6 +31,8 @@
     iput-object p3, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->moduleUuid:Ljava/lang/String;
 
     iput-wide p4, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->trackId:J
+
+    iput p6, p0, Lradiant/swipe/ArtistTrackCreditsQueueEvent;->action:I
 
     return-void
 .end method

--- a/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
@@ -1,0 +1,263 @@
+.class public final Lradiant/swipe/CompactGridMediaQueueAction;
+.super Ljava/lang/Object;
+.source "CompactGridMediaQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final itemId:Ljava/lang/String;
+
+.field private final mediaType:I
+
+.field private final moduleUuid:Ljava/lang/String;
+
+.field private final pageId:Ljava/lang/String;
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e;)V
+    .locals 3
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/CompactGridMediaQueueAction;->callback:Lam0/l;
+
+    iput-object p2, p0, Lradiant/swipe/CompactGridMediaQueueAction;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/CompactGridMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    instance-of v0, p4, Lm40/e$a;
+
+    if-eqz v0, :mix
+
+    check-cast p4, Lm40/e$a;
+
+    iget-wide v0, p4, Lm40/e$a;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v0
+
+    const/4 v1, 0x1
+
+    goto :store
+
+    :mix
+    instance-of v0, p4, Lm40/e$c;
+
+    if-eqz v0, :playlist
+
+    check-cast p4, Lm40/e$c;
+
+    iget-object v0, p4, Lm40/e$c;->a:Ljava/lang/String;
+
+    const/4 v1, 0x2
+
+    goto :store
+
+    :playlist
+    instance-of v0, p4, Lm40/e$d;
+
+    if-eqz v0, :track
+
+    check-cast p4, Lm40/e$d;
+
+    iget-object v0, p4, Lm40/e$d;->a:Ljava/lang/String;
+
+    const/4 v1, 0x3
+
+    goto :store
+
+    :track
+    instance-of v0, p4, Lm40/e$e;
+
+    if-eqz v0, :unsupported
+
+    check-cast p4, Lm40/e$e;
+
+    iget-wide v0, p4, Lm40/e$e;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v0
+
+    const/4 v1, 0x4
+
+    goto :store
+
+    :unsupported
+    const/4 v0, 0x0
+
+    const/4 v1, 0x0
+
+    :store
+    iput-object v0, p0, Lradiant/swipe/CompactGridMediaQueueAction;->itemId:Ljava/lang/String;
+
+    iput v1, p0, Lradiant/swipe/CompactGridMediaQueueAction;->mediaType:I
+
+    return-void
+.end method
+
+.method public static isEligible(Lm40/e;)Z
+    .locals 1
+
+    instance-of v0, p0, Lm40/e$a;
+
+    if-eqz v0, :mix
+
+    check-cast p0, Lm40/e$a;
+
+    iget-boolean p0, p0, Lm40/e$a;->e:Z
+
+    return p0
+
+    :mix
+    instance-of v0, p0, Lm40/e$c;
+
+    if-eqz v0, :playlist
+
+    check-cast p0, Lm40/e$c;
+
+    iget-boolean p0, p0, Lm40/e$c;->h:Z
+
+    return p0
+
+    :playlist
+    instance-of v0, p0, Lm40/e$d;
+
+    if-eqz v0, :track
+
+    check-cast p0, Lm40/e$d;
+
+    iget-boolean p0, p0, Lm40/e$d;->g:Z
+
+    return p0
+
+    :track
+    instance-of v0, p0, Lm40/e$e;
+
+    if-eqz v0, :invalid
+
+    check-cast p0, Lm40/e$e;
+
+    iget-boolean p0, p0, Lm40/e$e;->j:Z
+
+    return p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return p0
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 7
+
+    iget-object v6, p0, Lradiant/swipe/CompactGridMediaQueueAction;->callback:Lam0/l;
+
+    if-eqz v6, :done
+
+    iget-object v4, p0, Lradiant/swipe/CompactGridMediaQueueAction;->itemId:Ljava/lang/String;
+
+    if-eqz v4, :done
+
+    iget v5, p0, Lradiant/swipe/CompactGridMediaQueueAction;->mediaType:I
+
+    if-eqz v5, :done
+
+    const/4 v1, 0x4
+
+    if-ne v5, v1, :queue_event
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-nez v1, :queue_event
+
+    move-object v1, v4
+
+    goto :emit
+
+    :queue_event
+    iget-object v1, p0, Lradiant/swipe/CompactGridMediaQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    new-instance v0, Lradiant/swipe/DynamicMediaQueueEvent;
+
+    iget-object v2, p0, Lradiant/swipe/CompactGridMediaQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/CompactGridMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+
+    move-object v1, v0
+
+    :emit
+    invoke-interface {v6, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/CompactGridMediaQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method
+
+.method public stableKey()Ljava/lang/String;
+    .locals 3
+
+    iget-object v0, p0, Lradiant/swipe/CompactGridMediaQueueAction;->itemId:Ljava/lang/String;
+
+    if-eqz v0, :invalid
+
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    const-string v2, "cgc:"
+
+    invoke-direct {v1, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    iget-object v2, p0, Lradiant/swipe/CompactGridMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    const/16 v2, 0x3a
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    iget v2, p0, Lradiant/swipe/CompactGridMediaQueueAction;->mediaType:I
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+
+    const/16 v2, 0x3a
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
@@ -173,6 +173,10 @@
 
     if-eqz v5, :done
 
+    const/4 v1, 0x3
+
+    if-eq p1, v1, :queue_event
+
     const/4 v1, 0x4
 
     if-ne v5, v1, :queue_event

--- a/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/CompactGridMediaQueueAction.smali
@@ -158,12 +158,12 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
-    .locals 7
+.method public invoke(I)Ljava/lang/Object;
+    .locals 8
 
-    iget-object v6, p0, Lradiant/swipe/CompactGridMediaQueueAction;->callback:Lam0/l;
+    iget-object v7, p0, Lradiant/swipe/CompactGridMediaQueueAction;->callback:Lam0/l;
 
-    if-eqz v6, :done
+    if-eqz v7, :done
 
     iget-object v4, p0, Lradiant/swipe/CompactGridMediaQueueAction;->itemId:Ljava/lang/String;
 
@@ -198,15 +198,29 @@
 
     iget-object v3, p0, Lradiant/swipe/CompactGridMediaQueueAction;->moduleUuid:Ljava/lang/String;
 
-    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+    move v6, p1
+
+    invoke-direct/range {v0 .. v6}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
 
     move-object v1, v0
 
     :emit
-    invoke-interface {v6, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    invoke-interface {v7, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/CompactGridMediaQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/ComposeSearchQueue.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueue.smali
@@ -17,7 +17,7 @@
 
     if-lt v0, v1, :done
 
-    const/4 v1, 0x2
+    const/4 v1, 0x3
 
     if-gt v0, v1, :done
 
@@ -168,12 +168,19 @@
 
     check-cast v3, Lh40/p;
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x3
+
+    if-eq v0, v1, :queue_track
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v0
 
     if-eqz v0, :play_track
 
+    :queue_track
     invoke-static {v3}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
 
     move-result-object v9
@@ -212,9 +219,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_track
+    if-ne v0, v1, :check_add_track_to_playlist
 
     invoke-static {v8, v9, v7, v4}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_track_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v8, v9, v7, v4}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 
@@ -262,9 +278,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_album
+    if-ne v0, v1, :check_add_album_to_playlist
 
     invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_album_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 
@@ -288,9 +313,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_playlist
+    if-ne v0, v1, :check_add_playlist_to_playlist
 
     invoke-static {v8, v9, v7, v5}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :check_add_playlist_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v8, v9, v7, v5}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
 
@@ -310,9 +344,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_mix
+    if-ne v0, v1, :check_add_mix_to_playlist
 
     invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_mix_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/ComposeSearchQueue.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueue.smali
@@ -1,0 +1,270 @@
+.class public final Lradiant/swipe/ComposeSearchQueue;
+.super Ljava/lang/Object;
+.source "ComposeSearchQueue.smali"
+
+
+# direct methods
+.method public static handle(Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;Lradiant/swipe/ComposeSearchQueueEvent;)V
+    .locals 10
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget-object v8, p1, Lradiant/swipe/ComposeSearchQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v8, :done
+
+    iget-object v2, p1, Lradiant/swipe/ComposeSearchQueueEvent;->id:Ljava/lang/String;
+
+    if-eqz v2, :done
+
+    iget v4, p1, Lradiant/swipe/ComposeSearchQueueEvent;->type:I
+
+    const/4 v0, 0x1
+
+    if-lt v4, v0, :done
+
+    const/4 v0, 0x4
+
+    if-gt v4, v0, :done
+
+    iget-object v0, p0, Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;->n:Ljava/util/List;
+
+    invoke-interface {v0}, Ljava/lang/Iterable;->iterator()Ljava/util/Iterator;
+
+    move-result-object v0
+
+    :find_row
+    invoke-interface {v0}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    invoke-interface {v0}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lmb0/e;
+
+    invoke-static {v1}, Lmb0/f;->a(Lmb0/e;)Ljava/lang/String;
+
+    move-result-object v9
+
+    invoke-virtual {v2, v9}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v9
+
+    if-eqz v9, :find_row
+
+    instance-of v9, v1, Lmb0/a;
+
+    if-eqz v9, :find_row
+
+    check-cast v1, Lmb0/a;
+
+    iget-object v3, v1, Lmb0/a;->a:Lh40/n;
+
+    const/4 v9, 0x1
+
+    if-ne v4, v9, :check_album
+
+    instance-of v9, v3, Lh40/p;
+
+    if-eqz v9, :find_row
+
+    goto :recover_dependencies
+
+    :check_album
+    const/4 v9, 0x2
+
+    if-ne v4, v9, :check_playlist
+
+    instance-of v9, v3, Lh40/a;
+
+    if-eqz v9, :find_row
+
+    goto :recover_dependencies
+
+    :check_playlist
+    const/4 v9, 0x3
+
+    if-ne v4, v9, :check_mix
+
+    instance-of v9, v3, Lh40/j;
+
+    if-eqz v9, :find_row
+
+    goto :recover_dependencies
+
+    :check_mix
+    instance-of v9, v3, Lh40/i;
+
+    if-eqz v9, :find_row
+
+    :recover_dependencies
+    iget-object v9, p0, Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;->d:Lcom/tidal/android/feature/search/ui/e;
+
+    instance-of v0, v9, Lv9/e;
+
+    if-eqz v0, :done
+
+    check-cast v9, Lv9/e;
+
+    iget-object v5, v9, Lv9/e;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    iget-object v9, v9, Lv9/e;->a:Lcom/aspiro/wamp/core/k;
+
+    const/4 v6, 0x0
+
+    const/4 v0, 0x2
+
+    if-eq v4, v0, :recover_menu
+
+    const/4 v0, 0x4
+
+    if-ne v4, v0, :dependencies_ready
+
+    :recover_menu
+
+    instance-of v0, v9, Lh9/p1;
+
+    if-eqz v0, :done
+
+    check-cast v9, Lh9/p1;
+
+    iget-object v9, v9, Lh9/p1;->b:Lx40/a;
+
+    instance-of v0, v9, Lh4/a;
+
+    if-eqz v0, :done
+
+    move-object v6, v9
+
+    check-cast v6, Lh4/a;
+
+    :dependencies_ready
+
+    new-instance v7, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    const-string v0, "search"
+
+    invoke-direct {v7, v0, v2}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;)V
+
+    const/4 v0, 0x1
+
+    if-ne v4, v0, :album
+
+    check-cast v3, Lh40/p;
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v0
+
+    if-eqz v0, :play_track
+
+    invoke-static {v3}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v9
+
+    iget-object v4, p0, Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;->m:Lkotlinx/coroutines/flow/MutableStateFlow;
+
+    invoke-interface {v4}, Lkotlinx/coroutines/flow/MutableStateFlow;->getValue()Ljava/lang/Object;
+
+    move-result-object v4
+
+    check-cast v4, Lcom/tidal/android/feature/search/ui/SearchQuery;
+
+    iget-object v4, v4, Lcom/tidal/android/feature/search/ui/SearchQuery;->a:Ljava/lang/String;
+
+    if-nez v4, :track_query_ready
+
+    const-string v4, ""
+
+    :track_query_ready
+    const/4 v1, 0x0
+
+    if-eqz v5, :track_navigation_ready
+
+    invoke-static {v5}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+
+    move-result-object v1
+
+    :track_navigation_ready
+    invoke-static {v2, v4, v1}, Lcom/aspiro/wamp/playqueue/source/model/b;->o(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v4
+
+    invoke-virtual {v4, v9}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v8, v9, v7, v4}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :play_track
+    iget-object v5, p0, Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;->m:Lkotlinx/coroutines/flow/MutableStateFlow;
+
+    invoke-interface {v5}, Lkotlinx/coroutines/flow/MutableStateFlow;->getValue()Ljava/lang/Object;
+
+    move-result-object v5
+
+    check-cast v5, Lcom/tidal/android/feature/search/ui/SearchQuery;
+
+    iget-object v5, v5, Lcom/tidal/android/feature/search/ui/SearchQuery;->a:Ljava/lang/String;
+
+    if-nez v5, :play_query_ready
+
+    const-string v5, ""
+
+    :play_query_ready
+    iget-object v9, p0, Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;->f:Lcom/tidal/android/feature/search/ui/f;
+
+    iget-wide v0, v3, Lh40/p;->a:J
+
+    invoke-interface {v9, v0, v1, v3, v5}, Lcom/tidal/android/feature/search/ui/f;->a(JLh40/p;Ljava/lang/String;)V
+
+    goto :done
+
+    :album
+    const/4 v0, 0x2
+
+    if-ne v4, v0, :playlist
+
+    check-cast v3, Lh40/a;
+
+    invoke-static {v3}, Lie0/a;->a(Lh40/a;)Lcom/aspiro/wamp/model/Album;
+
+    move-result-object v9
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :playlist
+    const/4 v0, 0x3
+
+    if-ne v4, v0, :mix
+
+    check-cast v3, Lh40/j;
+
+    invoke-static {v3}, Lie0/h;->a(Lh40/j;)Lcom/aspiro/wamp/model/Playlist;
+
+    move-result-object v9
+
+    invoke-static {v8, v9, v7, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :mix
+    check-cast v3, Lh40/i;
+
+    invoke-static {v3}, Lie0/g;->b(Lh40/i;)Lcom/aspiro/wamp/mix/model/Mix;
+
+    move-result-object v9
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSearchQueue.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueue.smali
@@ -11,6 +11,16 @@
 
     if-eqz p1, :done
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-lt v0, v1, :done
+
+    const/4 v1, 0x2
+
+    if-gt v0, v1, :done
+
     iget-object v8, p1, Lradiant/swipe/ComposeSearchQueueEvent;->context:Landroid/content/Context;
 
     if-eqz v8, :done
@@ -198,6 +208,17 @@
 
     invoke-virtual {v4, v9}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v8, v9, v7, v4}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v8, v9, v7, v4}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     goto :done
@@ -237,6 +258,17 @@
 
     move-result-object v9
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_album
     invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     goto :done
@@ -252,6 +284,17 @@
 
     move-result-object v9
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v8, v9, v7, v5}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v8, v9, v7, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
@@ -263,6 +306,17 @@
 
     move-result-object v9
 
+    iget v0, p1, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_mix
     invoke-static {v8, v9, v7, v5, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     :done

--- a/patches/extension/radiant/swipe/ComposeSearchQueueAction.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueueAction.smali
@@ -180,7 +180,7 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
+.method public invoke(I)Ljava/lang/Object;
     .locals 4
 
     iget-object v0, p0, Lradiant/swipe/ComposeSearchQueueAction;->callback:Lam0/l;
@@ -201,12 +201,24 @@
 
     new-instance p0, Lradiant/swipe/ComposeSearchQueueEvent;
 
-    invoke-direct {p0, v1, v2, v3}, Lradiant/swipe/ComposeSearchQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;I)V
+    invoke-direct {p0, v1, v2, v3, p1}, Lradiant/swipe/ComposeSearchQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;II)V
 
     invoke-interface {v0, p0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSearchQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/ComposeSearchQueueAction.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueueAction.smali
@@ -1,0 +1,220 @@
+.class public final Lradiant/swipe/ComposeSearchQueueAction;
+.super Ljava/lang/Object;
+.source "ComposeSearchQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final id:Ljava/lang/String;
+
+.field private final type:I
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Lpb0/b;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSearchQueueAction;->callback:Lam0/l;
+
+    invoke-static {p2}, Lradiant/swipe/ComposeSearchQueueAction;->key(Lpb0/b;)Ljava/lang/String;
+
+    move-result-object v0
+
+    iput-object v0, p0, Lradiant/swipe/ComposeSearchQueueAction;->id:Ljava/lang/String;
+
+    invoke-static {p2}, Lradiant/swipe/ComposeSearchQueueAction;->type(Lpb0/b;)I
+
+    move-result p1
+
+    iput p1, p0, Lradiant/swipe/ComposeSearchQueueAction;->type:I
+
+    return-void
+.end method
+
+.method public static key(Lpb0/b;)Ljava/lang/String;
+    .locals 2
+
+    instance-of v0, p0, Lpb0/b$i;
+
+    if-eqz v0, :album
+
+    check-cast p0, Lpb0/b$i;
+
+    iget-wide v0, p0, Lpb0/b$i;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object p0
+
+    return-object p0
+
+    :album
+    instance-of v0, p0, Lpb0/b$a;
+
+    if-eqz v0, :playlist
+
+    check-cast p0, Lpb0/b$a;
+
+    iget-wide v0, p0, Lpb0/b$a;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object p0
+
+    return-object p0
+
+    :playlist
+    instance-of v0, p0, Lpb0/b$f;
+
+    if-eqz v0, :mix
+
+    check-cast p0, Lpb0/b$f;
+
+    iget-object p0, p0, Lpb0/b$f;->a:Ljava/lang/String;
+
+    return-object p0
+
+    :mix
+    instance-of v0, p0, Lpb0/b$e;
+
+    if-eqz v0, :invalid
+
+    check-cast p0, Lpb0/b$e;
+
+    iget-object p0, p0, Lpb0/b$e;->a:Ljava/lang/String;
+
+    return-object p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return-object p0
+.end method
+
+.method public stableKey()Ljava/lang/String;
+    .locals 3
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSearchQueueAction;->id:Ljava/lang/String;
+
+    if-eqz v0, :invalid
+
+    iget v1, p0, Lradiant/swipe/ComposeSearchQueueAction;->type:I
+
+    if-eqz v1, :invalid
+
+    new-instance v2, Ljava/lang/StringBuilder;
+
+    invoke-direct {v2}, Ljava/lang/StringBuilder;-><init>()V
+
+    invoke-virtual {v2, v1}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+
+    const/16 v1, 0x3a
+
+    invoke-virtual {v2, v1}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v2, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method private static type(Lpb0/b;)I
+    .locals 1
+
+    instance-of v0, p0, Lpb0/b$i;
+
+    if-eqz v0, :album
+
+    const/4 p0, 0x1
+
+    return p0
+
+    :album
+    instance-of v0, p0, Lpb0/b$a;
+
+    if-eqz v0, :playlist
+
+    const/4 p0, 0x2
+
+    return p0
+
+    :playlist
+    instance-of v0, p0, Lpb0/b$f;
+
+    if-eqz v0, :mix
+
+    const/4 p0, 0x3
+
+    return p0
+
+    :mix
+    instance-of p0, p0, Lpb0/b$e;
+
+    if-eqz p0, :invalid
+
+    const/4 p0, 0x4
+
+    return p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return p0
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 4
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSearchQueueAction;->callback:Lam0/l;
+
+    if-eqz v0, :done
+
+    iget-object v1, p0, Lradiant/swipe/ComposeSearchQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    iget-object v2, p0, Lradiant/swipe/ComposeSearchQueueAction;->id:Ljava/lang/String;
+
+    if-eqz v2, :done
+
+    iget v3, p0, Lradiant/swipe/ComposeSearchQueueAction;->type:I
+
+    if-eqz v3, :done
+
+    new-instance p0, Lradiant/swipe/ComposeSearchQueueEvent;
+
+    invoke-direct {p0, v1, v2, v3}, Lradiant/swipe/ComposeSearchQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;I)V
+
+    invoke-interface {v0, p0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSearchQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSearchQueueEvent.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueueEvent.smali
@@ -1,0 +1,40 @@
+.class public final Lradiant/swipe/ComposeSearchQueueEvent;
+.super Ljava/lang/Object;
+.source "ComposeSearchQueueEvent.smali"
+
+# interfaces
+.implements Lcom/tidal/android/feature/search/ui/b;
+
+
+# static fields
+.field public static final TYPE_ALBUM:I = 0x2
+
+.field public static final TYPE_MIX:I = 0x4
+
+.field public static final TYPE_PLAYLIST:I = 0x3
+
+.field public static final TYPE_TRACK:I = 0x1
+
+
+# instance fields
+.field public final context:Landroid/content/Context;
+
+.field public final id:Ljava/lang/String;
+
+.field public final type:I
+
+
+# direct methods
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;I)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSearchQueueEvent;->context:Landroid/content/Context;
+
+    iput-object p2, p0, Lradiant/swipe/ComposeSearchQueueEvent;->id:Ljava/lang/String;
+
+    iput p3, p0, Lradiant/swipe/ComposeSearchQueueEvent;->type:I
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSearchQueueEvent.smali
+++ b/patches/extension/radiant/swipe/ComposeSearchQueueEvent.smali
@@ -17,6 +17,8 @@
 
 
 # instance fields
+.field public final action:I
+
 .field public final context:Landroid/content/Context;
 
 .field public final id:Ljava/lang/String;
@@ -25,7 +27,7 @@
 
 
 # direct methods
-.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;I)V
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;II)V
     .locals 0
 
     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
@@ -35,6 +37,8 @@
     iput-object p2, p0, Lradiant/swipe/ComposeSearchQueueEvent;->id:Ljava/lang/String;
 
     iput p3, p0, Lradiant/swipe/ComposeSearchQueueEvent;->type:I
+
+    iput p4, p0, Lradiant/swipe/ComposeSearchQueueEvent;->action:I
 
     return-void
 .end method

--- a/patches/extension/radiant/swipe/ComposeSwipeAction.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeAction.smali
@@ -1,0 +1,14 @@
+.class public interface abstract Lradiant/swipe/ComposeSwipeAction;
+.super Ljava/lang/Object;
+.source "ComposeSwipeAction.smali"
+
+# interfaces
+.implements Lam0/a;
+
+
+# virtual methods
+.method public abstract invoke()Ljava/lang/Object;
+.end method
+
+.method public abstract setContext(Landroid/content/Context;)V
+.end method

--- a/patches/extension/radiant/swipe/ComposeSwipeAction.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeAction.smali
@@ -10,5 +10,8 @@
 .method public abstract invoke()Ljava/lang/Object;
 .end method
 
+.method public abstract invoke(I)Ljava/lang/Object;
+.end method
+
 .method public abstract setContext(Landroid/content/Context;)V
 .end method

--- a/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
@@ -1,0 +1,227 @@
+.class public final Lradiant/swipe/ComposeSwipeState$Draw;
+.super Ljava/lang/Object;
+.implements Lam0/l;
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = Lradiant/swipe/ComposeSwipeState;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x19
+    name = "Draw"
+.end annotation
+
+
+# instance fields
+.field private final state:Lradiant/swipe/ComposeSwipeState;
+
+
+# direct methods
+.method public constructor <init>(Lradiant/swipe/ComposeSwipeState;)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSwipeState$Draw;->state:Lradiant/swipe/ComposeSwipeState;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke(Landroidx/compose/ui/graphics/drawscope/ContentDrawScope;)Lkotlin/u;
+    .locals 16
+
+    move-object/from16 v0, p1
+
+    move-object/from16 v5, p0
+
+    invoke-interface {v0}, Landroidx/compose/ui/graphics/drawscope/DrawScope;->getSize-NH-jbRc()J
+
+    move-result-wide v1
+
+    invoke-static {v1, v2}, Landroidx/compose/ui/geometry/Size;->getWidth-impl(J)F
+
+    move-result v3
+
+    invoke-static {v1, v2}, Landroidx/compose/ui/geometry/Size;->getHeight-impl(J)F
+
+    move-result v4
+
+    iget-object v5, v5, Lradiant/swipe/ComposeSwipeState$Draw;->state:Lradiant/swipe/ComposeSwipeState;
+
+    iput v3, v5, Lradiant/swipe/ComposeSwipeState;->rowWidth:F
+
+    iget-object v1, v5, Lradiant/swipe/ComposeSwipeState;->translation:Landroidx/compose/runtime/MutableFloatState;
+
+    invoke-interface {v1}, Landroidx/compose/runtime/MutableFloatState;->getFloatValue()F
+
+    move-result v6
+
+    const/4 v1, 0x0
+
+    cmpl-float v2, v6, v1
+
+    if-eqz v2, :draw_plain
+
+    invoke-interface {v0}, Landroidx/compose/ui/graphics/drawscope/DrawScope;->getDrawContext()Landroidx/compose/ui/graphics/drawscope/DrawContext;
+
+    move-result-object v2
+
+    invoke-interface {v2}, Landroidx/compose/ui/graphics/drawscope/DrawContext;->getCanvas()Landroidx/compose/ui/graphics/Canvas;
+
+    move-result-object v2
+
+    invoke-static {v2}, Landroidx/compose/ui/graphics/AndroidCanvas_androidKt;->getNativeCanvas(Landroidx/compose/ui/graphics/Canvas;)Landroid/graphics/Canvas;
+
+    move-result-object v7
+
+    invoke-virtual {v7}, Landroid/graphics/Canvas;->save()I
+
+    move-result v8
+
+    const/16 v9, __RL_SWIPE_TO_QUEUE_DIRECTION__
+
+    const/4 v10, 0x4
+
+    if-ne v9, v10, :right_exposure
+
+    add-float v9, v3, v6
+
+    invoke-static {v1, v9}, Ljava/lang/Math;->max(FF)F
+
+    move-result v9
+
+    move v10, v3
+
+    goto :exposure_ready
+
+    :right_exposure
+    move v9, v1
+
+    invoke-static {v3, v6}, Ljava/lang/Math;->min(FF)F
+
+    move-result v10
+
+    :exposure_ready
+    invoke-virtual {v7, v9, v1, v10, v4}, Landroid/graphics/Canvas;->clipRect(FFFF)Z
+
+    iget v11, v5, Lradiant/swipe/ComposeSwipeState;->green:I
+
+    invoke-virtual {v7, v11}, Landroid/graphics/Canvas;->drawColor(I)V
+
+    iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->icon:Landroid/graphics/drawable/Drawable;
+
+    if-eqz v11, :background_done
+
+    invoke-virtual {v11}, Landroid/graphics/drawable/Drawable;->getIntrinsicWidth()I
+
+    move-result v12
+
+    invoke-virtual {v11}, Landroid/graphics/drawable/Drawable;->getIntrinsicHeight()I
+
+    move-result v13
+
+    if-lez v12, :background_done
+
+    if-lez v13, :background_done
+
+    const/high16 v14, 0x41800000 # 16.0f
+
+    invoke-virtual {v5, v14}, Lradiant/swipe/ComposeSwipeState;->dp(F)F
+
+    move-result v14
+
+    const/16 v15, __RL_SWIPE_TO_QUEUE_DIRECTION__
+
+    const/4 v1, 0x4
+
+    if-ne v15, v1, :right_icon
+
+    int-to-float v1, v12
+
+    sub-float v1, v3, v1
+
+    sub-float/2addr v1, v14
+
+    goto :icon_x_ready
+
+    :right_icon
+    move v1, v14
+
+    :icon_x_ready
+    int-to-float v14, v13
+
+    sub-float v14, v4, v14
+
+    const/high16 v15, 0x40000000 # 2.0f
+
+    div-float/2addr v14, v15
+
+    float-to-int v15, v1
+
+    float-to-int v14, v14
+
+    add-int v1, v15, v12
+
+    add-int v12, v14, v13
+
+    invoke-virtual {v11, v15, v14, v1, v12}, Landroid/graphics/drawable/Drawable;->setBounds(IIII)V
+
+    const/16 v1, 0xff
+
+    invoke-virtual {v11, v1}, Landroid/graphics/drawable/Drawable;->setAlpha(I)V
+
+    invoke-virtual {v11, v7}, Landroid/graphics/drawable/Drawable;->draw(Landroid/graphics/Canvas;)V
+
+    :background_done
+    invoke-virtual {v7, v8}, Landroid/graphics/Canvas;->restoreToCount(I)V
+
+    invoke-virtual {v7}, Landroid/graphics/Canvas;->save()I
+
+    move-result v8
+
+    const/4 v1, 0x0
+
+    invoke-virtual {v7, v1, v1, v3, v4}, Landroid/graphics/Canvas;->clipRect(FFFF)Z
+
+    invoke-virtual {v7, v6, v1}, Landroid/graphics/Canvas;->translate(FF)V
+
+    :try_start_0
+    invoke-interface {v0}, Landroidx/compose/ui/graphics/drawscope/ContentDrawScope;->drawContent()V
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_0
+
+    invoke-virtual {v7, v8}, Landroid/graphics/Canvas;->restoreToCount(I)V
+
+    goto :done
+
+    :catchall_0
+    move-exception v0
+
+    invoke-virtual {v7, v8}, Landroid/graphics/Canvas;->restoreToCount(I)V
+
+    throw v0
+
+    :draw_plain
+    invoke-interface {v0}, Landroidx/compose/ui/graphics/drawscope/ContentDrawScope;->drawContent()V
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public bridge synthetic invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    .locals 1
+
+    check-cast p1, Landroidx/compose/ui/graphics/drawscope/ContentDrawScope;
+
+    invoke-virtual {p0, p1}, Lradiant/swipe/ComposeSwipeState$Draw;->invoke(Landroidx/compose/ui/graphics/drawscope/ContentDrawScope;)Lkotlin/u;
+
+    move-result-object v0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
@@ -82,11 +82,9 @@
 
     move-result v8
 
-    const/16 v9, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    cmpg-float v9, v6, v1
 
-    const/4 v10, 0x4
-
-    if-ne v9, v10, :right_exposure
+    if-gez v9, :right_exposure
 
     add-float v9, v3, v6
 
@@ -108,11 +106,41 @@
     :exposure_ready
     invoke-virtual {v7, v9, v1, v10, v4}, Landroid/graphics/Canvas;->clipRect(FFFF)Z
 
-    iget v11, v5, Lradiant/swipe/ComposeSwipeState;->backgroundColor:I
+    invoke-virtual {v5, v6}, Lradiant/swipe/ComposeSwipeState;->actionForOffset(F)I
+
+    move-result v11
+
+    const/4 v12, 0x1
+
+    if-ne v11, v12, :add_color
+
+    const v11, __RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR__
+
+    goto :color_ready
+
+    :add_color
+    const v11, __RL_SWIPE_TO_QUEUE_ADD_COLOR__
+
+    :color_ready
 
     invoke-virtual {v7, v11}, Landroid/graphics/Canvas;->drawColor(I)V
 
-    iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->icon:Landroid/graphics/drawable/Drawable;
+    invoke-virtual {v5, v6}, Lradiant/swipe/ComposeSwipeState;->actionForOffset(F)I
+
+    move-result v11
+
+    const/4 v12, 0x1
+
+    if-ne v11, v12, :add_icon
+
+    iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->playNextIcon:Landroid/graphics/drawable/Drawable;
+
+    goto :icon_ready
+
+    :add_icon
+    iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->addIcon:Landroid/graphics/drawable/Drawable;
+
+    :icon_ready
 
     if-eqz v11, :background_done
 
@@ -134,11 +162,13 @@
 
     move-result v14
 
-    const/16 v15, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    const/4 v15, 0x0
 
-    const/4 v1, 0x4
+    int-to-float v15, v15
 
-    if-ne v15, v1, :right_icon
+    cmpg-float v15, v6, v15
+
+    if-gez v15, :right_icon
 
     int-to-float v1, v12
 

--- a/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
@@ -119,6 +119,15 @@
     goto :color_ready
 
     :add_color
+    const/4 v12, 0x3
+
+    if-ne v11, v12, :add_to_queue_color
+
+    const v11, __RL_SWIPE_TO_QUEUE_ADD_TO_PLAYLIST_COLOR__
+
+    goto :color_ready
+
+    :add_to_queue_color
     const v11, __RL_SWIPE_TO_QUEUE_ADD_COLOR__
 
     :color_ready
@@ -138,6 +147,15 @@
     goto :icon_ready
 
     :add_icon
+    const/4 v12, 0x3
+
+    if-ne v11, v12, :add_to_queue_icon
+
+    iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
+
+    goto :icon_ready
+
+    :add_to_queue_icon
     iget-object v11, v5, Lradiant/swipe/ComposeSwipeState;->addIcon:Landroid/graphics/drawable/Drawable;
 
     :icon_ready

--- a/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$Draw.smali
@@ -108,7 +108,7 @@
     :exposure_ready
     invoke-virtual {v7, v9, v1, v10, v4}, Landroid/graphics/Canvas;->clipRect(FFFF)Z
 
-    iget v11, v5, Lradiant/swipe/ComposeSwipeState;->green:I
+    iget v11, v5, Lradiant/swipe/ComposeSwipeState;->backgroundColor:I
 
     invoke-virtual {v7, v11}, Landroid/graphics/Canvas;->drawColor(I)V
 

--- a/patches/extension/radiant/swipe/ComposeSwipeState$Gesture.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$Gesture.smali
@@ -1,0 +1,231 @@
+.class public final Lradiant/swipe/ComposeSwipeState$Gesture;
+.super Landroidx/compose/ui/input/pointer/PointerInputFilter;
+.implements Lam0/l;
+.implements Landroidx/compose/ui/input/pointer/PointerInputModifier;
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = Lradiant/swipe/ComposeSwipeState;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x19
+    name = "Gesture"
+.end annotation
+
+
+# instance fields
+.field private consumeAfterDispatch:Z
+
+.field private final state:Lradiant/swipe/ComposeSwipeState;
+
+
+# direct methods
+.method public constructor <init>(Lradiant/swipe/ComposeSwipeState;)V
+    .locals 0
+
+    invoke-direct {p0}, Landroidx/compose/ui/input/pointer/PointerInputFilter;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public getInterceptOutOfBoundsChildEvents()Z
+    .locals 1
+
+    const/4 v0, 0x1
+
+    return v0
+.end method
+
+.method public getPointerInputFilter()Landroidx/compose/ui/input/pointer/PointerInputFilter;
+    .locals 0
+
+    return-object p0
+.end method
+
+.method public invoke(Landroid/view/MotionEvent;)Lkotlin/u;
+    .locals 3
+
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getActionMasked()I
+
+    move-result v0
+
+    const/4 v1, 0x0
+
+    iput-boolean v1, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->consumeAfterDispatch:Z
+
+    if-eqz v0, :down
+
+    const/4 v1, 0x1
+
+    if-eq v0, v1, :up
+
+    const/4 v1, 0x2
+
+    if-eq v0, v1, :move
+
+    const/4 v1, 0x3
+
+    if-eq v0, v1, :cancel
+
+    const/4 v1, 0x5
+
+    if-eq v0, v1, :cancel
+
+    const/4 v1, 0x6
+
+    if-eq v0, v1, :cancel
+
+    goto :done
+
+    :down
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawX()F
+
+    move-result v0
+
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawY()F
+
+    move-result v1
+
+    iget-object v2, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v2, v0, v1}, Lradiant/swipe/ComposeSwipeState;->begin(FF)V
+
+    goto :done
+
+    :move
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawX()F
+
+    move-result v0
+
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawY()F
+
+    move-result v1
+
+    iget-object v2, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v2, v0, v1}, Lradiant/swipe/ComposeSwipeState;->move(FF)V
+
+    goto :done
+
+    :up
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawX()F
+
+    move-result v0
+
+    invoke-virtual {p1}, Landroid/view/MotionEvent;->getRawY()F
+
+    move-result v1
+
+    iget-object v2, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v2, v0, v1}, Lradiant/swipe/ComposeSwipeState;->move(FF)V
+
+    iget-boolean v0, v2, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->consumeAfterDispatch:Z
+
+    invoke-virtual {v2}, Lradiant/swipe/ComposeSwipeState;->finish()V
+
+    goto :done
+
+    :cancel
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v0}, Lradiant/swipe/ComposeSwipeState;->cancelGesture()V
+
+    :done
+    sget-object p1, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object p1
+.end method
+
+.method public bridge synthetic invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    .locals 1
+
+    check-cast p1, Landroid/view/MotionEvent;
+
+    invoke-virtual {p0, p1}, Lradiant/swipe/ComposeSwipeState$Gesture;->invoke(Landroid/view/MotionEvent;)Lkotlin/u;
+
+    move-result-object v0
+
+    return-object v0
+.end method
+
+.method public onCancel()V
+    .locals 1
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v0}, Lradiant/swipe/ComposeSwipeState;->cancelGesture()V
+
+    return-void
+.end method
+
+.method public onPointerEvent-H0pRuoY(Landroidx/compose/ui/input/pointer/PointerEvent;Landroidx/compose/ui/input/pointer/PointerEventPass;J)V
+    .locals 4
+
+    sget-object v0, Landroidx/compose/ui/input/pointer/PointerEventPass;->Initial:Landroidx/compose/ui/input/pointer/PointerEventPass;
+
+    if-ne p2, v0, :done
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->state:Lradiant/swipe/ComposeSwipeState;
+
+    iget-boolean v1, v0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    const/4 v2, 0x0
+
+    iput-boolean v2, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->consumeAfterDispatch:Z
+
+    invoke-virtual {p1}, Landroidx/compose/ui/input/pointer/PointerEvent;->getMotionEvent()Landroid/view/MotionEvent;
+
+    move-result-object v2
+
+    if-eqz v2, :after_dispatch
+
+    invoke-virtual {p0, v2}, Lradiant/swipe/ComposeSwipeState$Gesture;->invoke(Landroid/view/MotionEvent;)Lkotlin/u;
+
+    :after_dispatch
+    iget-boolean v2, p0, Lradiant/swipe/ComposeSwipeState$Gesture;->consumeAfterDispatch:Z
+
+    or-int/2addr v1, v2
+
+    iget-boolean v2, v0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    or-int/2addr v1, v2
+
+    if-eqz v1, :done
+
+    invoke-virtual {p1}, Landroidx/compose/ui/input/pointer/PointerEvent;->getChanges()Ljava/util/List;
+
+    move-result-object v0
+
+    invoke-interface {v0}, Ljava/util/List;->size()I
+
+    move-result v1
+
+    const/4 v2, 0x0
+
+    :consume_loop
+    if-ge v2, v1, :done
+
+    invoke-interface {v0, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v3
+
+    check-cast v3, Landroidx/compose/ui/input/pointer/PointerInputChange;
+
+    invoke-virtual {v3}, Landroidx/compose/ui/input/pointer/PointerInputChange;->consume()V
+
+    add-int/lit8 v2, v2, 0x1
+
+    goto :consume_loop
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSwipeState$ResetAnimator.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState$ResetAnimator.smali
@@ -1,0 +1,67 @@
+.class public final Lradiant/swipe/ComposeSwipeState$ResetAnimator;
+.super Ljava/lang/Object;
+.implements Landroid/animation/ValueAnimator$AnimatorUpdateListener;
+
+
+# annotations
+.annotation system Ldalvik/annotation/EnclosingClass;
+    value = Lradiant/swipe/ComposeSwipeState;
+.end annotation
+
+.annotation system Ldalvik/annotation/InnerClass;
+    accessFlags = 0x19
+    name = "ResetAnimator"
+.end annotation
+
+
+# instance fields
+.field private final state:Lradiant/swipe/ComposeSwipeState;
+
+
+# direct methods
+.method public constructor <init>(Lradiant/swipe/ComposeSwipeState;)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSwipeState$ResetAnimator;->state:Lradiant/swipe/ComposeSwipeState;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public onAnimationUpdate(Landroid/animation/ValueAnimator;)V
+    .locals 3
+
+    invoke-virtual {p1}, Landroid/animation/ValueAnimator;->getAnimatedValue()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Ljava/lang/Float;
+
+    invoke-virtual {v0}, Ljava/lang/Float;->floatValue()F
+
+    move-result v0
+
+    iget-object v1, p0, Lradiant/swipe/ComposeSwipeState$ResetAnimator;->state:Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v1, v0}, Lradiant/swipe/ComposeSwipeState;->setOffset(F)V
+
+    invoke-virtual {p1}, Landroid/animation/ValueAnimator;->getAnimatedFraction()F
+
+    move-result v0
+
+    const/high16 v2, 0x3f800000 # 1.0f
+
+    cmpg-float v0, v0, v2
+
+    if-gez v0, :finished
+
+    return-void
+
+    :finished
+    invoke-virtual {v1, p1}, Lradiant/swipe/ComposeSwipeState;->clearAnimator(Landroid/animation/ValueAnimator;)V
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSwipeState.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState.smali
@@ -33,7 +33,7 @@
 
 .field icon:Landroid/graphics/drawable/Drawable;
 
-.field green:I
+.field backgroundColor:I
 
 
 # direct methods
@@ -606,13 +606,9 @@
     :load_resources
     iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->context:Landroid/content/Context;
 
-    sget v1, Lcom/aspiro/wamp/R$color;->green:I
+    const v1, __RL_SWIPE_TO_QUEUE_COLOR__
 
-    invoke-virtual {v0, v1}, Landroid/content/Context;->getColor(I)I
-
-    move-result v1
-
-    iput v1, p0, Lradiant/swipe/ComposeSwipeState;->green:I
+    iput v1, p0, Lradiant/swipe/ComposeSwipeState;->backgroundColor:I
 
     sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
 

--- a/patches/extension/radiant/swipe/ComposeSwipeState.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState.smali
@@ -33,6 +33,8 @@
 
 .field addIcon:Landroid/graphics/drawable/Drawable;
 
+.field addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
+
 .field playNextIcon:Landroid/graphics/drawable/Drawable;
 
 
@@ -658,6 +660,25 @@
 
     :store_play_next_icon
     iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->playNextIcon:Landroid/graphics/drawable/Drawable;
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_playlist:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    if-eqz v1, :store_add_to_playlist_icon
+
+    invoke-virtual {v1}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    const/4 v2, -0x1
+
+    invoke-virtual {v1, v2}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_add_to_playlist_icon
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->addToPlaylistIcon:Landroid/graphics/drawable/Drawable;
 
     :context_ready
     if-eqz p1, :enabled_ready

--- a/patches/extension/radiant/swipe/ComposeSwipeState.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState.smali
@@ -1,0 +1,657 @@
+.class public final Lradiant/swipe/ComposeSwipeState;
+.super Ljava/lang/Object;
+
+
+# instance fields
+.field translation:Landroidx/compose/runtime/MutableFloatState;
+
+.field action:Lradiant/swipe/ComposeSwipeAction;
+
+.field context:Landroid/content/Context;
+
+.field view:Landroid/view/View;
+
+.field enabled:Z
+
+.field downX:F
+
+.field downY:F
+
+.field tracking:Z
+
+.field locked:Z
+
+.field armed:Z
+
+.field rowWidth:F
+
+.field animator:Landroid/animation/ValueAnimator;
+
+.field final gesture:Lradiant/swipe/ComposeSwipeState$Gesture;
+
+.field final draw:Lradiant/swipe/ComposeSwipeState$Draw;
+
+.field icon:Landroid/graphics/drawable/Drawable;
+
+.field green:I
+
+
+# direct methods
+.method public constructor <init>()V
+    .locals 2
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    const/4 v0, 0x0
+
+    invoke-static {v0}, Landroidx/compose/runtime/PrimitiveSnapshotStateKt;->mutableFloatStateOf(F)Landroidx/compose/runtime/MutableFloatState;
+
+    move-result-object v0
+
+    iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->translation:Landroidx/compose/runtime/MutableFloatState;
+
+    new-instance v0, Lradiant/swipe/ComposeSwipeState$Gesture;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/ComposeSwipeState$Gesture;-><init>(Lradiant/swipe/ComposeSwipeState;)V
+
+    iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->gesture:Lradiant/swipe/ComposeSwipeState$Gesture;
+
+    new-instance v1, Lradiant/swipe/ComposeSwipeState$Draw;
+
+    invoke-direct {v1, p0}, Lradiant/swipe/ComposeSwipeState$Draw;-><init>(Lradiant/swipe/ComposeSwipeState;)V
+
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->draw:Lradiant/swipe/ComposeSwipeState$Draw;
+
+    return-void
+.end method
+
+.method public static attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
+    .locals 5
+    .annotation build Landroidx/compose/runtime/Composable;
+    .end annotation
+
+    const v0, 0x4a33c921
+
+    invoke-interface {p4, v0}, Landroidx/compose/runtime/Composer;->startReplaceGroup(I)V
+
+    invoke-static {}, Landroidx/compose/ui/platform/AndroidCompositionLocals_androidKt;->getLocalView()Landroidx/compose/runtime/ProvidableCompositionLocal;
+
+    move-result-object v0
+
+    invoke-interface {p4, v0}, Landroidx/compose/runtime/Composer;->consume(Landroidx/compose/runtime/CompositionLocal;)Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Landroid/view/View;
+
+    invoke-interface {p4, p1}, Landroidx/compose/runtime/Composer;->changed(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    invoke-interface {p4}, Landroidx/compose/runtime/Composer;->rememberedValue()Ljava/lang/Object;
+
+    move-result-object v2
+
+    if-nez v1, :new_state
+
+    sget-object v3, Landroidx/compose/runtime/Composer;->Companion:Landroidx/compose/runtime/Composer$Companion;
+
+    invoke-virtual {v3}, Landroidx/compose/runtime/Composer$Companion;->getEmpty()Ljava/lang/Object;
+
+    move-result-object v3
+
+    if-ne v2, v3, :state_ready
+
+    :new_state
+    new-instance v2, Lradiant/swipe/ComposeSwipeState;
+
+    invoke-direct {v2}, Lradiant/swipe/ComposeSwipeState;-><init>()V
+
+    invoke-interface {p4, v2}, Landroidx/compose/runtime/Composer;->updateRememberedValue(Ljava/lang/Object;)V
+
+    :state_ready
+    check-cast v2, Lradiant/swipe/ComposeSwipeState;
+
+    invoke-virtual {v2, p2, p3, v0}, Lradiant/swipe/ComposeSwipeState;->update(Lradiant/swipe/ComposeSwipeAction;ZLandroid/view/View;)V
+
+    iget-object v1, v2, Lradiant/swipe/ComposeSwipeState;->gesture:Lradiant/swipe/ComposeSwipeState$Gesture;
+
+    check-cast v1, Landroidx/compose/ui/Modifier;
+
+    invoke-interface {p0, v1}, Landroidx/compose/ui/Modifier;->then(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+
+    move-result-object p0
+
+    iget-object v1, v2, Lradiant/swipe/ComposeSwipeState;->draw:Lradiant/swipe/ComposeSwipeState$Draw;
+
+    invoke-static {p0, v1}, Landroidx/compose/ui/draw/DrawModifierKt;->drawWithContent(Landroidx/compose/ui/Modifier;Lam0/l;)Landroidx/compose/ui/Modifier;
+
+    move-result-object p0
+
+    invoke-interface {p4}, Landroidx/compose/runtime/Composer;->endReplaceGroup()V
+
+    return-object p0
+.end method
+
+
+# virtual methods
+.method animateReset()V
+    .locals 7
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    const/4 v1, 0x0
+
+    if-eqz v0, :read_offset
+
+    invoke-virtual {v0}, Landroid/animation/ValueAnimator;->cancel()V
+
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    :read_offset
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->translation:Landroidx/compose/runtime/MutableFloatState;
+
+    invoke-interface {v0}, Landroidx/compose/runtime/MutableFloatState;->getFloatValue()F
+
+    move-result v0
+
+    invoke-static {v0}, Ljava/lang/Math;->abs(F)F
+
+    move-result v2
+
+    const/high16 v3, 0x3f000000 # 0.5f
+
+    cmpg-float v2, v2, v3
+
+    if-lez v2, :snap
+
+    const/4 v2, 0x2
+
+    new-array v2, v2, [F
+
+    const/4 v3, 0x0
+
+    aput v0, v2, v3
+
+    const/4 v0, 0x1
+
+    const/4 v3, 0x0
+
+    aput v3, v2, v0
+
+    invoke-static {v2}, Landroid/animation/ValueAnimator;->ofFloat([F)Landroid/animation/ValueAnimator;
+
+    move-result-object v0
+
+    const-wide/16 v4, 0xb4
+
+    invoke-virtual {v0, v4, v5}, Landroid/animation/ValueAnimator;->setDuration(J)Landroid/animation/ValueAnimator;
+
+    new-instance v2, Landroid/view/animation/DecelerateInterpolator;
+
+    const/high16 v4, 0x3fc00000 # 1.5f
+
+    invoke-direct {v2, v4}, Landroid/view/animation/DecelerateInterpolator;-><init>(F)V
+
+    invoke-virtual {v0, v2}, Landroid/animation/ValueAnimator;->setInterpolator(Landroid/animation/TimeInterpolator;)V
+
+    new-instance v2, Lradiant/swipe/ComposeSwipeState$ResetAnimator;
+
+    invoke-direct {v2, p0}, Lradiant/swipe/ComposeSwipeState$ResetAnimator;-><init>(Lradiant/swipe/ComposeSwipeState;)V
+
+    invoke-virtual {v0, v2}, Landroid/animation/ValueAnimator;->addUpdateListener(Landroid/animation/ValueAnimator$AnimatorUpdateListener;)V
+
+    iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    invoke-virtual {v0}, Landroid/animation/ValueAnimator;->start()V
+
+    return-void
+
+    :snap
+    const/4 v3, 0x0
+
+    invoke-virtual {p0, v3}, Lradiant/swipe/ComposeSwipeState;->setOffset(F)V
+
+    return-void
+.end method
+
+.method begin(FF)V
+    .locals 3
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->releaseParent()V
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    const/4 v1, 0x0
+
+    if-eqz v0, :initialize
+
+    invoke-virtual {v0}, Landroid/animation/ValueAnimator;->cancel()V
+
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    :initialize
+    iput p1, p0, Lradiant/swipe/ComposeSwipeState;->downX:F
+
+    iput p2, p0, Lradiant/swipe/ComposeSwipeState;->downY:F
+
+    const/4 v0, 0x0
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->setOffset(F)V
+
+    iget-boolean v2, p0, Lradiant/swipe/ComposeSwipeState;->enabled:Z
+
+    if-eqz v2, :inactive
+
+    iget-object v2, p0, Lradiant/swipe/ComposeSwipeState;->action:Lradiant/swipe/ComposeSwipeAction;
+
+    if-eqz v2, :inactive
+
+    const/4 v0, 0x1
+
+    :inactive
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->tracking:Z
+
+    return-void
+.end method
+
+.method cancelGesture()V
+    .locals 1
+
+    const/4 v0, 0x0
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->tracking:Z
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->releaseParent()V
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->animateReset()V
+
+    return-void
+.end method
+
+.method clearAnimator(Landroid/animation/ValueAnimator;)V
+    .locals 1
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    if-ne v0, p1, :done
+
+    const/4 v0, 0x0
+
+    iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->animator:Landroid/animation/ValueAnimator;
+
+    :done
+    return-void
+.end method
+
+.method dp(F)F
+    .locals 1
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->context:Landroid/content/Context;
+
+    if-eqz v0, :done
+
+    invoke-virtual {v0}, Landroid/content/Context;->getResources()Landroid/content/res/Resources;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Landroid/content/res/Resources;->getDisplayMetrics()Landroid/util/DisplayMetrics;
+
+    move-result-object v0
+
+    iget v0, v0, Landroid/util/DisplayMetrics;->density:F
+
+    mul-float/2addr p1, v0
+
+    :done
+    return p1
+.end method
+
+.method finish()V
+    .locals 3
+
+    iget-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->tracking:Z
+
+    if-eqz v0, :reset_only
+
+    iget-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    if-eqz v0, :not_complete
+
+    iget-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    if-eqz v0, :not_complete
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->translation:Landroidx/compose/runtime/MutableFloatState;
+
+    invoke-interface {v0}, Landroidx/compose/runtime/MutableFloatState;->getFloatValue()F
+
+    move-result v0
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->isCorrectDirection(F)Z
+
+    move-result v0
+
+    goto :complete_ready
+
+    :not_complete
+    const/4 v0, 0x0
+
+    :complete_ready
+    const/4 v1, 0x0
+
+    iput-boolean v1, p0, Lradiant/swipe/ComposeSwipeState;->tracking:Z
+
+    iput-boolean v1, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    iput-boolean v1, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->releaseParent()V
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->animateReset()V
+
+    if-eqz v0, :done
+
+    invoke-static {}, Lradiant/swipe/ComposeTapGuard;->suppressAfterSwipe()V
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->action:Lradiant/swipe/ComposeSwipeAction;
+
+    if-eqz v0, :done
+
+    invoke-interface {v0}, Lradiant/swipe/ComposeSwipeAction;->invoke()Ljava/lang/Object;
+
+    goto :done
+
+    :reset_only
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->releaseParent()V
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->animateReset()V
+
+    :done
+    return-void
+.end method
+
+.method isCorrectDirection(F)Z
+    .locals 3
+
+    const/16 v0, __RL_SWIPE_TO_QUEUE_DIRECTION__
+
+    const/4 v1, 0x4
+
+    const/4 v2, 0x0
+
+    if-ne v0, v1, :expect_right
+
+    cmpg-float v0, p1, v2
+
+    if-gez v0, :wrong
+
+    const/4 v0, 0x1
+
+    return v0
+
+    :expect_right
+    cmpl-float v0, p1, v2
+
+    if-lez v0, :wrong
+
+    const/4 v0, 0x1
+
+    return v0
+
+    :wrong
+    const/4 v0, 0x0
+
+    return v0
+.end method
+
+.method move(FF)V
+    .locals 8
+
+    iget-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->tracking:Z
+
+    if-eqz v0, :done
+
+    iget v0, p0, Lradiant/swipe/ComposeSwipeState;->downX:F
+
+    sub-float v0, p1, v0
+
+    iget v1, p0, Lradiant/swipe/ComposeSwipeState;->downY:F
+
+    sub-float v1, p2, v1
+
+    iget-boolean v2, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    if-nez v2, :publish
+
+    invoke-static {v0}, Ljava/lang/Math;->abs(F)F
+
+    move-result v2
+
+    invoke-static {v1}, Ljava/lang/Math;->abs(F)F
+
+    move-result v3
+
+    const/high16 v4, 0x41000000 # 8.0f
+
+    invoke-virtual {p0, v4}, Lradiant/swipe/ComposeSwipeState;->dp(F)F
+
+    move-result v4
+
+    cmpg-float v5, v2, v4
+
+    if-gez v5, :axis_ready
+
+    cmpg-float v5, v3, v4
+
+    if-ltz v5, :done
+
+    :axis_ready
+    cmpg-float v5, v2, v3
+
+    if-gtz v5, :horizontal_candidate
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->cancelGesture()V
+
+    return-void
+
+    :horizontal_candidate
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->isCorrectDirection(F)Z
+
+    move-result v5
+
+    if-nez v5, :lock
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->cancelGesture()V
+
+    return-void
+
+    :lock
+    const/4 v5, 0x1
+
+    iput-boolean v5, p0, Lradiant/swipe/ComposeSwipeState;->locked:Z
+
+    iget-object v6, p0, Lradiant/swipe/ComposeSwipeState;->view:Landroid/view/View;
+
+    if-eqz v6, :publish
+
+    invoke-virtual {v6}, Landroid/view/View;->getParent()Landroid/view/ViewParent;
+
+    move-result-object v6
+
+    if-eqz v6, :publish
+
+    invoke-interface {v6, v5}, Landroid/view/ViewParent;->requestDisallowInterceptTouchEvent(Z)V
+
+    :publish
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->isCorrectDirection(F)Z
+
+    move-result v2
+
+    if-nez v2, :set_offset
+
+    const/4 v2, 0x0
+
+    invoke-virtual {p0, v2}, Lradiant/swipe/ComposeSwipeState;->setOffset(F)V
+
+    iput-boolean v2, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    return-void
+
+    :set_offset
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->setOffset(F)V
+
+    iget v2, p0, Lradiant/swipe/ComposeSwipeState;->rowWidth:F
+
+    const/4 v3, 0x0
+
+    cmpg-float v4, v2, v3
+
+    if-lez v4, :done
+
+    const v4, 0x3e99999a # 0.3f
+
+    mul-float/2addr v2, v4
+
+    invoke-static {v0}, Ljava/lang/Math;->abs(F)F
+
+    move-result v0
+
+    cmpg-float v0, v0, v2
+
+    if-ltz v0, :below_threshold
+
+    const/4 v0, 0x1
+
+    goto :arm_ready
+
+    :below_threshold
+    const/4 v0, 0x0
+
+    :arm_ready
+    iget-boolean v1, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    if-eq v0, v1, :done
+
+    iput-boolean v0, p0, Lradiant/swipe/ComposeSwipeState;->armed:Z
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->view:Landroid/view/View;
+
+    if-eqz v0, :done
+
+    const/4 v1, 0x4
+
+    invoke-virtual {v0, v1}, Landroid/view/View;->performHapticFeedback(I)Z
+
+    :done
+    return-void
+.end method
+
+.method releaseParent()V
+    .locals 2
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->view:Landroid/view/View;
+
+    if-eqz v0, :done
+
+    invoke-virtual {v0}, Landroid/view/View;->getParent()Landroid/view/ViewParent;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    const/4 v1, 0x0
+
+    invoke-interface {v0, v1}, Landroid/view/ViewParent;->requestDisallowInterceptTouchEvent(Z)V
+
+    :done
+    return-void
+.end method
+
+.method setOffset(F)V
+    .locals 1
+
+    iget-object v0, p0, Lradiant/swipe/ComposeSwipeState;->translation:Landroidx/compose/runtime/MutableFloatState;
+
+    invoke-interface {v0, p1}, Landroidx/compose/runtime/MutableFloatState;->setFloatValue(F)V
+
+    return-void
+.end method
+
+.method update(Lradiant/swipe/ComposeSwipeAction;ZLandroid/view/View;)V
+    .locals 4
+
+    iput-object p1, p0, Lradiant/swipe/ComposeSwipeState;->action:Lradiant/swipe/ComposeSwipeAction;
+
+    iput-object p3, p0, Lradiant/swipe/ComposeSwipeState;->view:Landroid/view/View;
+
+    invoke-virtual {p3}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    iget-object v1, p0, Lradiant/swipe/ComposeSwipeState;->context:Landroid/content/Context;
+
+    if-ne v0, v1, :load_resources
+
+    goto :context_ready
+
+    :load_resources
+    iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->context:Landroid/content/Context;
+
+    sget v1, Lcom/aspiro/wamp/R$color;->green:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getColor(I)I
+
+    move-result v1
+
+    iput v1, p0, Lradiant/swipe/ComposeSwipeState;->green:I
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    if-eqz v1, :store_icon
+
+    invoke-virtual {v1}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    const/4 v2, -0x1
+
+    invoke-virtual {v1, v2}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_icon
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->icon:Landroid/graphics/drawable/Drawable;
+
+    :context_ready
+    if-eqz p1, :enabled_ready
+
+    invoke-interface {p1, v0}, Lradiant/swipe/ComposeSwipeAction;->setContext(Landroid/content/Context;)V
+
+    :enabled_ready
+    iget-boolean v1, p0, Lradiant/swipe/ComposeSwipeState;->enabled:Z
+
+    iput-boolean p2, p0, Lradiant/swipe/ComposeSwipeState;->enabled:Z
+
+    if-nez v1, :was_enabled
+
+    return-void
+
+    :was_enabled
+    if-nez p2, :done
+
+    invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->cancelGesture()V
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ComposeSwipeState.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState.smali
@@ -31,9 +31,9 @@
 
 .field final draw:Lradiant/swipe/ComposeSwipeState$Draw;
 
-.field icon:Landroid/graphics/drawable/Drawable;
+.field addIcon:Landroid/graphics/drawable/Drawable;
 
-.field backgroundColor:I
+.field playNextIcon:Landroid/graphics/drawable/Drawable;
 
 
 # direct methods
@@ -135,6 +135,36 @@
 
 
 # virtual methods
+.method actionForOffset(F)I
+    .locals 2
+
+    const/4 v0, 0x0
+
+    int-to-float v0, v0
+
+    cmpg-float v1, p1, v0
+
+    if-ltz v1, :left
+
+    cmpl-float p1, p1, v0
+
+    if-gtz p1, :right
+
+    const/4 p1, 0x0
+
+    return p1
+
+    :left
+    const/16 p1, __RL_SWIPE_TO_QUEUE_LEFT_ACTION__
+
+    return p1
+
+    :right
+    const/16 p1, __RL_SWIPE_TO_QUEUE_RIGHT_ACTION__
+
+    return p1
+.end method
+
 .method animateReset()V
     .locals 7
 
@@ -336,14 +366,14 @@
 
     move-result v0
 
-    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->isCorrectDirection(F)Z
+    invoke-virtual {p0, v0}, Lradiant/swipe/ComposeSwipeState;->actionForOffset(F)I
 
-    move-result v0
+    move-result v2
 
     goto :complete_ready
 
     :not_complete
-    const/4 v0, 0x0
+    const/4 v2, 0x0
 
     :complete_ready
     const/4 v1, 0x0
@@ -358,7 +388,7 @@
 
     invoke-virtual {p0}, Lradiant/swipe/ComposeSwipeState;->animateReset()V
 
-    if-eqz v0, :done
+    if-eqz v2, :done
 
     invoke-static {}, Lradiant/swipe/ComposeTapGuard;->suppressAfterSwipe()V
 
@@ -366,7 +396,7 @@
 
     if-eqz v0, :done
 
-    invoke-interface {v0}, Lradiant/swipe/ComposeSwipeAction;->invoke()Ljava/lang/Object;
+    invoke-interface {v0, v2}, Lradiant/swipe/ComposeSwipeAction;->invoke(I)Ljava/lang/Object;
 
     goto :done
 
@@ -380,28 +410,13 @@
 .end method
 
 .method isCorrectDirection(F)Z
-    .locals 3
+    .locals 1
 
-    const/16 v0, __RL_SWIPE_TO_QUEUE_DIRECTION__
+    invoke-virtual {p0, p1}, Lradiant/swipe/ComposeSwipeState;->actionForOffset(F)I
 
-    const/4 v1, 0x4
+    move-result v0
 
-    const/4 v2, 0x0
-
-    if-ne v0, v1, :expect_right
-
-    cmpg-float v0, p1, v2
-
-    if-gez v0, :wrong
-
-    const/4 v0, 0x1
-
-    return v0
-
-    :expect_right
-    cmpl-float v0, p1, v2
-
-    if-lez v0, :wrong
+    if-eqz v0, :wrong
 
     const/4 v0, 0x1
 
@@ -606,10 +621,6 @@
     :load_resources
     iput-object v0, p0, Lradiant/swipe/ComposeSwipeState;->context:Landroid/content/Context;
 
-    const v1, __RL_SWIPE_TO_QUEUE_COLOR__
-
-    iput v1, p0, Lradiant/swipe/ComposeSwipeState;->backgroundColor:I
-
     sget v1, Lcom/aspiro/wamp/R$drawable;->ic_add_to_queue_last:I
 
     invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
@@ -627,7 +638,26 @@
     invoke-virtual {v1, v2}, Landroid/graphics/drawable/Drawable;->setTint(I)V
 
     :store_icon
-    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->icon:Landroid/graphics/drawable/Drawable;
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->addIcon:Landroid/graphics/drawable/Drawable;
+
+    sget v1, Lcom/aspiro/wamp/R$drawable;->ic_play_next:I
+
+    invoke-virtual {v0, v1}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    if-eqz v1, :store_play_next_icon
+
+    invoke-virtual {v1}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
+
+    move-result-object v1
+
+    const/4 v2, -0x1
+
+    invoke-virtual {v1, v2}, Landroid/graphics/drawable/Drawable;->setTint(I)V
+
+    :store_play_next_icon
+    iput-object v1, p0, Lradiant/swipe/ComposeSwipeState;->playNextIcon:Landroid/graphics/drawable/Drawable;
 
     :context_ready
     if-eqz p1, :enabled_ready

--- a/patches/extension/radiant/swipe/ComposeSwipeState.smali
+++ b/patches/extension/radiant/swipe/ComposeSwipeState.smali
@@ -448,11 +448,11 @@
 
     cmpg-float v5, v2, v4
 
-    if-gez v5, :axis_ready
+    if-ltz v5, :axis_ready
 
     cmpg-float v5, v3, v4
 
-    if-ltz v5, :done
+    if-gez v5, :done
 
     :axis_ready
     cmpg-float v5, v2, v3

--- a/patches/extension/radiant/swipe/ComposeTapGuard.smali
+++ b/patches/extension/radiant/swipe/ComposeTapGuard.smali
@@ -1,0 +1,97 @@
+.class public final Lradiant/swipe/ComposeTapGuard;
+.super Ljava/lang/Object;
+.implements Lam0/a;
+
+
+# static fields
+.field private static volatile deadline:J
+
+
+# instance fields
+.field private final delegate:Lam0/a;
+
+
+# direct methods
+.method public constructor <init>(Lam0/a;)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ComposeTapGuard;->delegate:Lam0/a;
+
+    return-void
+.end method
+
+.method public static isSuppressed()Z
+    .locals 5
+
+    invoke-static {}, Landroid/os/SystemClock;->uptimeMillis()J
+
+    move-result-wide v0
+
+    sget-wide v2, Lradiant/swipe/ComposeTapGuard;->deadline:J
+
+    cmp-long v4, v0, v2
+
+    if-ltz v4, :suppressed
+
+    const/4 v0, 0x0
+
+    return v0
+
+    :suppressed
+    const/4 v0, 0x1
+
+    return v0
+.end method
+
+.method public static suppressAfterSwipe()V
+    .locals 4
+
+    invoke-static {}, Landroid/os/SystemClock;->uptimeMillis()J
+
+    move-result-wide v0
+
+    const-wide/16 v2, 0x96
+
+    add-long/2addr v0, v2
+
+    sput-wide v0, Lradiant/swipe/ComposeTapGuard;->deadline:J
+
+    return-void
+.end method
+
+.method public static wrap(Lam0/a;)Lam0/a;
+    .locals 1
+
+    new-instance v0, Lradiant/swipe/ComposeTapGuard;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/ComposeTapGuard;-><init>(Lam0/a;)V
+
+    return-object v0
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    invoke-static {}, Lradiant/swipe/ComposeTapGuard;->isSuppressed()Z
+
+    move-result v0
+
+    if-eqz v0, :dispatch
+
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+
+    :dispatch
+    iget-object v0, p0, Lradiant/swipe/ComposeTapGuard;->delegate:Lam0/a;
+
+    invoke-interface {v0}, Lam0/a;->invoke()Ljava/lang/Object;
+
+    move-result-object v0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/DynamicMediaQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicMediaQueue.smali
@@ -11,6 +11,16 @@
 
     if-eqz p1, :done
 
+    iget v4, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v5, 0x1
+
+    if-lt v4, v5, :done
+
+    const/4 v5, 0x2
+
+    if-gt v4, v5, :done
+
     iget-object v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
 
     iget-object v1, p1, Lradiant/swipe/DynamicMediaQueueEvent;->moduleUuid:Ljava/lang/String;
@@ -172,6 +182,17 @@
 
     if-eqz v6, :done
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_album
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     goto :done
@@ -193,6 +214,17 @@
 
     if-eqz v6, :done
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_mix
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     goto :done
@@ -208,6 +240,17 @@
 
     move-result-object v12
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
@@ -236,6 +279,17 @@
 
     invoke-virtual {v11, v12}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done
@@ -248,6 +302,16 @@
     if-eqz p0, :done
 
     if-eqz p1, :done
+
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-lt v0, v1, :done
+
+    const/4 v1, 0x2
+
+    if-gt v0, v1, :done
 
     iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
 
@@ -362,6 +426,17 @@
 
     move-result-object v4
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v6, v4, v8, v7}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v6, v4, v8, v7}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     :done
@@ -374,6 +449,16 @@
     if-eqz p0, :done
 
     if-eqz p1, :done
+
+    iget v4, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v5, 0x1
+
+    if-lt v4, v5, :done
+
+    const/4 v5, 0x2
+
+    if-gt v4, v5, :done
 
     iget-object v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
 
@@ -536,6 +621,17 @@
 
     if-eqz v6, :done
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_album
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     goto :done
@@ -557,6 +653,17 @@
 
     if-eqz v6, :done
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_mix
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     goto :done
@@ -572,6 +679,17 @@
 
     move-result-object v12
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
@@ -600,6 +718,17 @@
 
     invoke-virtual {v11, v12}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
+
+    const/4 v1, 0x1
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done

--- a/patches/extension/radiant/swipe/DynamicMediaQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicMediaQueue.smali
@@ -1,0 +1,634 @@
+.class public final Lradiant/swipe/DynamicMediaQueue;
+.super Ljava/lang/Object;
+.source "DynamicMediaQueue.smali"
+
+
+# direct methods
+.method public static handleCompact(Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/a;Lradiant/swipe/DynamicMediaQueueEvent;)V
+    .locals 13
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget-object v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
+
+    iget-object v1, p1, Lradiant/swipe/DynamicMediaQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iget-object v2, p1, Lradiant/swipe/DynamicMediaQueueEvent;->itemId:Ljava/lang/String;
+
+    iget v3, p1, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
+
+    if-eqz v0, :done
+
+    if-eqz v1, :done
+
+    if-eqz v2, :done
+
+    const/4 v4, 0x1
+
+    if-lt v3, v4, :done
+
+    const/4 v4, 0x4
+
+    if-gt v3, v4, :done
+
+    invoke-virtual {p0, v1}, Li60/c;->c(Ljava/lang/String;)Lc60/h;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lc60/f;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lc60/f;
+
+    iget-object v5, v4, Lc60/f;->b:Ljava/lang/String;
+
+    invoke-virtual {v1, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    iget-object v1, v4, Lc60/f;->g:Ljava/util/ArrayList;
+
+    invoke-virtual {v1}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v1
+
+    :find_media
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v5
+
+    if-eqz v5, :done
+
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v6
+
+    instance-of v5, v6, Lc60/r;
+
+    if-eqz v5, :find_media
+
+    check-cast v6, Lc60/r;
+
+    invoke-static {v6}, Lc60/s;->a(Lc60/r;)Ljava/lang/String;
+
+    move-result-object v5
+
+    invoke-virtual {v2, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v5
+
+    if-eqz v5, :find_media
+
+    instance-of v5, v6, Lc60/r$b;
+
+    if-eqz v5, :done
+
+    check-cast v6, Lc60/r$b;
+
+    iget-object v7, v6, Lc60/r$b;->a:Lh40/n;
+
+    const/4 v5, 0x1
+
+    if-ne v3, v5, :check_mix
+
+    instance-of v5, v7, Lh40/a;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_mix
+    const/4 v5, 0x2
+
+    if-ne v3, v5, :check_playlist
+
+    instance-of v5, v7, Lh40/i;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_playlist
+    const/4 v5, 0x3
+
+    if-ne v3, v5, :check_track
+
+    instance-of v5, v7, Lh40/j;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_track
+    instance-of v5, v7, Lh40/p;
+
+    if-eqz v5, :done
+
+    :dependencies
+    iget-object v8, p0, Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/a;->b:Lcom/tidal/android/dynamicpages/ui/b;
+
+    instance-of v5, v8, Lcom/tidal/android/dynamicpages/ui/c;
+
+    if-eqz v5, :done
+
+    check-cast v8, Lcom/tidal/android/dynamicpages/ui/c;
+
+    iget-object v5, p1, Lradiant/swipe/DynamicMediaQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v5, :done
+
+    iget-object v9, v8, Lcom/tidal/android/dynamicpages/ui/c;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    new-instance v10, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v11, v4, Lc60/f;->a:Ljava/lang/String;
+
+    iget v12, v4, Lc60/f;->d:I
+
+    invoke-static {v12}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v12
+
+    invoke-direct {v10, v0, v11, v12}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    const/4 v0, 0x1
+
+    if-ne v3, v0, :mix
+
+    check-cast v7, Lh40/a;
+
+    invoke-static {v7}, Lie0/a;->a(Lh40/a;)Lcom/aspiro/wamp/model/Album;
+
+    move-result-object v12
+
+    invoke-static {v8}, Lradiant/swipe/DynamicMediaQueue;->menu(Lcom/tidal/android/dynamicpages/ui/c;)Lh4/a;
+
+    move-result-object v6
+
+    if-eqz v6, :done
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :mix
+    const/4 v0, 0x2
+
+    if-ne v3, v0, :playlist
+
+    check-cast v7, Lh40/i;
+
+    invoke-static {v7}, Lie0/g;->b(Lh40/i;)Lcom/aspiro/wamp/mix/model/Mix;
+
+    move-result-object v12
+
+    invoke-static {v8}, Lradiant/swipe/DynamicMediaQueue;->menu(Lcom/tidal/android/dynamicpages/ui/c;)Lh4/a;
+
+    move-result-object v6
+
+    if-eqz v6, :done
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :playlist
+    const/4 v0, 0x3
+
+    if-ne v3, v0, :track
+
+    check-cast v7, Lh40/j;
+
+    invoke-static {v7}, Lie0/h;->a(Lh40/j;)Lcom/aspiro/wamp/model/Playlist;
+
+    move-result-object v12
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :track
+    check-cast v7, Lh40/p;
+
+    invoke-static {v7}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v12
+
+    const/4 v6, 0x0
+
+    if-eqz v9, :navigation_ready
+
+    invoke-static {v9}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+
+    move-result-object v6
+
+    :navigation_ready
+    iget-object v0, v4, Lc60/f;->e:Ljava/lang/String;
+
+    invoke-static {v2, v0, v6}, Lcom/aspiro/wamp/playqueue/source/model/b;->o(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v11
+
+    invoke-virtual {v11, v12}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method
+
+.method public static handlePublicPlaylist(Lcom/tidal/android/dynamicpages/ui/modules/publicplaylistlist/PublicPlaylistListModuleManager;Lradiant/swipe/DynamicMediaQueueEvent;)V
+    .locals 11
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
+
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :done
+
+    iget-object v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
+
+    iget-object v1, p1, Lradiant/swipe/DynamicMediaQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iget-object v2, p1, Lradiant/swipe/DynamicMediaQueueEvent;->itemId:Ljava/lang/String;
+
+    if-eqz v0, :done
+
+    if-eqz v1, :done
+
+    if-eqz v2, :done
+
+    invoke-virtual {p0, v1}, Li60/c;->c(Ljava/lang/String;)Lc60/h;
+
+    move-result-object v3
+
+    instance-of v4, v3, Lc60/v;
+
+    if-eqz v4, :done
+
+    check-cast v3, Lc60/v;
+
+    iget-object v4, v3, Lc60/v;->b:Ljava/lang/String;
+
+    invoke-virtual {v1, v4}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    iget-object v1, v3, Lc60/v;->f:Ljava/util/ArrayList;
+
+    invoke-virtual {v1}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v1
+
+    :find_playlist
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v4
+
+    if-eqz v4, :done
+
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lc60/r;
+
+    if-eqz v5, :find_playlist
+
+    check-cast v4, Lc60/r;
+
+    invoke-static {v4}, Lc60/s;->a(Lc60/r;)Ljava/lang/String;
+
+    move-result-object v5
+
+    invoke-virtual {v2, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v5
+
+    if-eqz v5, :find_playlist
+
+    instance-of v5, v4, Lc60/r$b;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lc60/r$b;
+
+    iget-object v4, v4, Lc60/r$b;->a:Lh40/n;
+
+    instance-of v5, v4, Lh40/j;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lh40/j;
+
+    iget-object v5, p0, Lcom/tidal/android/dynamicpages/ui/modules/publicplaylistlist/PublicPlaylistListModuleManager;->f:Lcom/tidal/android/dynamicpages/ui/b;
+
+    instance-of v6, v5, Lcom/tidal/android/dynamicpages/ui/c;
+
+    if-eqz v6, :done
+
+    check-cast v5, Lcom/tidal/android/dynamicpages/ui/c;
+
+    iget-object v6, p1, Lradiant/swipe/DynamicMediaQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v6, :done
+
+    iget-object v7, v5, Lcom/tidal/android/dynamicpages/ui/c;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    new-instance v8, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v9, v3, Lc60/v;->a:Ljava/lang/String;
+
+    iget v10, v3, Lc60/v;->e:I
+
+    invoke-static {v10}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v10
+
+    invoke-direct {v8, v0, v9, v10}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    invoke-static {v4}, Lie0/h;->a(Lh40/j;)Lcom/aspiro/wamp/model/Playlist;
+
+    move-result-object v4
+
+    invoke-static {v6, v4, v8, v7}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    :done
+    return-void
+.end method
+
+.method public static handleVertical(Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/VerticalListCardModuleManager;Lradiant/swipe/DynamicMediaQueueEvent;)V
+    .locals 13
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget-object v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
+
+    iget-object v1, p1, Lradiant/swipe/DynamicMediaQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iget-object v2, p1, Lradiant/swipe/DynamicMediaQueueEvent;->itemId:Ljava/lang/String;
+
+    iget v3, p1, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
+
+    if-eqz v0, :done
+
+    if-eqz v1, :done
+
+    if-eqz v2, :done
+
+    const/4 v4, 0x1
+
+    if-lt v3, v4, :done
+
+    const/4 v4, 0x4
+
+    if-gt v3, v4, :done
+
+    invoke-virtual {p0, v1}, Li60/c;->c(Ljava/lang/String;)Lc60/h;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lc60/c0;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lc60/c0;
+
+    iget-object v5, v4, Lc60/c0;->b:Ljava/lang/String;
+
+    invoke-virtual {v1, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    iget-object v1, v4, Lc60/c0;->g:Ljava/util/ArrayList;
+
+    invoke-virtual {v1}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v1
+
+    :find_media
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v5
+
+    if-eqz v5, :done
+
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v6
+
+    instance-of v5, v6, Lc60/r;
+
+    if-eqz v5, :find_media
+
+    check-cast v6, Lc60/r;
+
+    invoke-static {v6}, Lc60/s;->a(Lc60/r;)Ljava/lang/String;
+
+    move-result-object v5
+
+    invoke-virtual {v2, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v5
+
+    if-eqz v5, :find_media
+
+    instance-of v5, v6, Lc60/r$b;
+
+    if-eqz v5, :done
+
+    check-cast v6, Lc60/r$b;
+
+    iget-object v7, v6, Lc60/r$b;->a:Lh40/n;
+
+    const/4 v5, 0x1
+
+    if-ne v3, v5, :check_mix
+
+    instance-of v5, v7, Lh40/a;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_mix
+    const/4 v5, 0x2
+
+    if-ne v3, v5, :check_playlist
+
+    instance-of v5, v7, Lh40/i;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_playlist
+    const/4 v5, 0x3
+
+    if-ne v3, v5, :check_track
+
+    instance-of v5, v7, Lh40/j;
+
+    if-eqz v5, :done
+
+    goto :dependencies
+
+    :check_track
+    instance-of v5, v7, Lh40/p;
+
+    if-eqz v5, :done
+
+    :dependencies
+    iget-object v8, p0, Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/VerticalListCardModuleManager;->e:Lcom/tidal/android/dynamicpages/ui/b;
+
+    instance-of v5, v8, Lcom/tidal/android/dynamicpages/ui/c;
+
+    if-eqz v5, :done
+
+    check-cast v8, Lcom/tidal/android/dynamicpages/ui/c;
+
+    iget-object v5, p1, Lradiant/swipe/DynamicMediaQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v5, :done
+
+    iget-object v9, v8, Lcom/tidal/android/dynamicpages/ui/c;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    new-instance v10, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v11, v4, Lc60/c0;->a:Ljava/lang/String;
+
+    iget v12, v4, Lc60/c0;->f:I
+
+    invoke-static {v12}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v12
+
+    invoke-direct {v10, v0, v11, v12}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    const/4 v0, 0x1
+
+    if-ne v3, v0, :mix
+
+    check-cast v7, Lh40/a;
+
+    invoke-static {v7}, Lie0/a;->a(Lh40/a;)Lcom/aspiro/wamp/model/Album;
+
+    move-result-object v12
+
+    invoke-static {v8}, Lradiant/swipe/DynamicMediaQueue;->menu(Lcom/tidal/android/dynamicpages/ui/c;)Lh4/a;
+
+    move-result-object v6
+
+    if-eqz v6, :done
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :mix
+    const/4 v0, 0x2
+
+    if-ne v3, v0, :playlist
+
+    check-cast v7, Lh40/i;
+
+    invoke-static {v7}, Lie0/g;->b(Lh40/i;)Lcom/aspiro/wamp/mix/model/Mix;
+
+    move-result-object v12
+
+    invoke-static {v8}, Lradiant/swipe/DynamicMediaQueue;->menu(Lcom/tidal/android/dynamicpages/ui/c;)Lh4/a;
+
+    move-result-object v6
+
+    if-eqz v6, :done
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :playlist
+    const/4 v0, 0x3
+
+    if-ne v3, v0, :track
+
+    check-cast v7, Lh40/j;
+
+    invoke-static {v7}, Lie0/h;->a(Lh40/j;)Lcom/aspiro/wamp/model/Playlist;
+
+    move-result-object v12
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :track
+    check-cast v7, Lh40/p;
+
+    invoke-static {v7}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v12
+
+    const/4 v6, 0x0
+
+    if-eqz v9, :navigation_ready
+
+    invoke-static {v9}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+
+    move-result-object v6
+
+    :navigation_ready
+    iget-object v0, v4, Lc60/c0;->c:Ljava/lang/String;
+
+    invoke-static {v2, v0, v6}, Lcom/aspiro/wamp/playqueue/source/model/b;->o(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v11
+
+    invoke-virtual {v11, v12}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method
+
+.method private static menu(Lcom/tidal/android/dynamicpages/ui/c;)Lh4/a;
+    .locals 2
+
+    iget-object v0, p0, Lcom/tidal/android/dynamicpages/ui/c;->a:Lcom/aspiro/wamp/core/k;
+
+    instance-of v1, v0, Lh9/p1;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lh9/p1;
+
+    iget-object v0, v0, Lh9/p1;->b:Lx40/a;
+
+    instance-of v1, v0, Lh4/a;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lh4/a;
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/DynamicMediaQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicMediaQueue.smali
@@ -17,7 +17,7 @@
 
     if-lt v4, v5, :done
 
-    const/4 v5, 0x2
+    const/4 v5, 0x3
 
     if-gt v4, v5, :done
 
@@ -186,9 +186,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_album
+    if-ne v0, v1, :check_add_album_to_playlist
 
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_album_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 
@@ -218,9 +227,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_mix
+    if-ne v0, v1, :check_add_mix_to_playlist
 
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_mix_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 
@@ -244,9 +262,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_playlist
+    if-ne v0, v1, :check_add_playlist_to_playlist
 
     invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :check_add_playlist_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
 
@@ -283,9 +310,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_track
+    if-ne v0, v1, :check_add_track_to_playlist
 
     invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_track_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 
@@ -309,7 +345,7 @@
 
     if-lt v0, v1, :done
 
-    const/4 v1, 0x2
+    const/4 v1, 0x3
 
     if-gt v0, v1, :done
 
@@ -430,9 +466,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_playlist
+    if-ne v0, v1, :check_add_playlist_to_playlist
 
     invoke-static {v6, v4, v8, v7}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :check_add_playlist_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v6, v4, v8, v7}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
 
@@ -456,7 +501,7 @@
 
     if-lt v4, v5, :done
 
-    const/4 v5, 0x2
+    const/4 v5, 0x3
 
     if-gt v4, v5, :done
 
@@ -625,9 +670,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_album
+    if-ne v0, v1, :check_add_album_to_playlist
 
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_album_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_album
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 
@@ -657,9 +711,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_mix
+    if-ne v0, v1, :check_add_mix_to_playlist
 
     invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :check_add_mix_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_mix
+
+    invoke-static {v5, v12, v10, v9, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     goto :done
 
@@ -683,9 +746,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_playlist
+    if-ne v0, v1, :check_add_playlist_to_playlist
 
     invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :check_add_playlist_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_playlist
+
+    invoke-static {v5, v12, v10, v9}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
 
@@ -722,9 +794,18 @@
 
     const/4 v1, 0x1
 
-    if-ne v0, v1, :append_track
+    if-ne v0, v1, :check_add_track_to_playlist
 
     invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_track_to_playlist
+    const/4 v1, 0x3
+
+    if-ne v0, v1, :append_track
+
+    invoke-static {v5, v12, v10, v11}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/DynamicMediaQueueEvent.smali
+++ b/patches/extension/radiant/swipe/DynamicMediaQueueEvent.smali
@@ -8,6 +8,8 @@
 
 
 # instance fields
+.field public final action:I
+
 .field public final context:Landroid/content/Context;
 
 .field public final itemId:Ljava/lang/String;
@@ -20,7 +22,7 @@
 
 
 # direct methods
-.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
     .locals 0
 
     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
@@ -34,6 +36,8 @@
     iput-object p4, p0, Lradiant/swipe/DynamicMediaQueueEvent;->itemId:Ljava/lang/String;
 
     iput p5, p0, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
+
+    iput p6, p0, Lradiant/swipe/DynamicMediaQueueEvent;->action:I
 
     return-void
 .end method

--- a/patches/extension/radiant/swipe/DynamicMediaQueueEvent.smali
+++ b/patches/extension/radiant/swipe/DynamicMediaQueueEvent.smali
@@ -1,0 +1,39 @@
+.class public final Lradiant/swipe/DynamicMediaQueueEvent;
+.super Ljava/lang/Object;
+.source "DynamicMediaQueueEvent.smali"
+
+# interfaces
+.implements Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/b;
+.implements Lcom/tidal/android/dynamicpages/ui/modules/publicplaylistlist/b;
+
+
+# instance fields
+.field public final context:Landroid/content/Context;
+
+.field public final itemId:Ljava/lang/String;
+
+.field public final mediaType:I
+
+.field public final moduleUuid:Ljava/lang/String;
+
+.field public final pageId:Ljava/lang/String;
+
+
+# direct methods
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/DynamicMediaQueueEvent;->context:Landroid/content/Context;
+
+    iput-object p2, p0, Lradiant/swipe/DynamicMediaQueueEvent;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/DynamicMediaQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iput-object p4, p0, Lradiant/swipe/DynamicMediaQueueEvent;->itemId:Ljava/lang/String;
+
+    iput p5, p0, Lradiant/swipe/DynamicMediaQueueEvent;->mediaType:I
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/DynamicTrackQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueue.smali
@@ -162,6 +162,17 @@
 
     invoke-virtual {v9, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    iget v0, p1, Lradiant/swipe/DynamicTrackQueueEvent;->action:I
+
+    const/4 v2, 0x1
+
+    if-ne v0, v2, :append
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append
     invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done

--- a/patches/extension/radiant/swipe/DynamicTrackQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueue.smali
@@ -166,9 +166,18 @@
 
     const/4 v2, 0x1
 
-    if-ne v0, v2, :append
+    if-ne v0, v2, :check_add_to_playlist
 
     invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_to_playlist
+    const/4 v2, 0x3
+
+    if-ne v0, v2, :append
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/DynamicTrackQueue.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueue.smali
@@ -1,0 +1,169 @@
+.class public final Lradiant/swipe/DynamicTrackQueue;
+.super Ljava/lang/Object;
+.source "DynamicTrackQueue.smali"
+
+
+# direct methods
+.method public static handle(Lcom/tidal/android/dynamicpages/ui/modules/tracklist/TrackListModuleManager;Lradiant/swipe/DynamicTrackQueueEvent;)V
+    .locals 11
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    iget-object v0, p1, Lradiant/swipe/DynamicTrackQueueEvent;->pageId:Ljava/lang/String;
+
+    if-eqz v0, :done
+
+    invoke-virtual {v0}, Ljava/lang/String;->length()I
+
+    move-result v1
+
+    if-lez v1, :done
+
+    iget-object v1, p1, Lradiant/swipe/DynamicTrackQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v1}, Ljava/lang/String;->length()I
+
+    move-result v2
+
+    if-lez v2, :done
+
+    iget-wide v2, p1, Lradiant/swipe/DynamicTrackQueueEvent;->trackId:J
+
+    const-wide/16 v4, 0x0
+
+    cmp-long v4, v2, v4
+
+    if-lez v4, :done
+
+    invoke-virtual {p0, v1}, Li60/c;->c(Ljava/lang/String;)Lc60/h;
+
+    move-result-object v4
+
+    instance-of v5, v4, Lc60/b0;
+
+    if-eqz v5, :done
+
+    check-cast v4, Lc60/b0;
+
+    iget-object v5, v4, Lc60/b0;->b:Ljava/lang/String;
+
+    invoke-virtual {v1, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v1
+
+    if-eqz v1, :done
+
+    iget-object v1, v4, Lc60/b0;->f:Ljava/util/ArrayList;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v1}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v1
+
+    :find_track
+    invoke-interface {v1}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v5
+
+    if-eqz v5, :done
+
+    invoke-interface {v1}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v5
+
+    instance-of v6, v5, Lc60/r$b;
+
+    if-eqz v6, :find_track
+
+    check-cast v5, Lc60/r$b;
+
+    iget-object v5, v5, Lc60/r$b;->a:Lh40/n;
+
+    instance-of v6, v5, Lh40/p;
+
+    if-eqz v6, :find_track
+
+    check-cast v5, Lh40/p;
+
+    iget-wide v6, v5, Lh40/p;->a:J
+
+    cmp-long v6, v6, v2
+
+    if-nez v6, :find_track
+
+    iget-object v1, p0, Lcom/tidal/android/dynamicpages/ui/modules/tracklist/TrackListModuleManager;->b:Lcom/tidal/android/dynamicpages/ui/b;
+
+    instance-of v2, v1, Lcom/tidal/android/dynamicpages/ui/c;
+
+    if-eqz v2, :done
+
+    check-cast v1, Lcom/tidal/android/dynamicpages/ui/c;
+
+    iget-object v6, v1, Lcom/tidal/android/dynamicpages/ui/c;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    if-eqz v6, :done
+
+    iget-object v1, p1, Lradiant/swipe/DynamicTrackQueueEvent;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    invoke-static {v5}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v7
+
+    if-eqz v7, :done
+
+    iget-object v2, v4, Lc60/b0;->a:Ljava/lang/String;
+
+    if-eqz v2, :done
+
+    invoke-virtual {v2}, Ljava/lang/String;->length()I
+
+    move-result v3
+
+    if-lez v3, :done
+
+    new-instance v8, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget v3, v4, Lc60/b0;->e:I
+
+    invoke-static {v3}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v3
+
+    invoke-direct {v8, v0, v2, v3}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    iget-wide v2, p1, Lradiant/swipe/DynamicTrackQueueEvent;->trackId:J
+
+    invoke-static {v2, v3}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v2
+
+    iget-object v3, v4, Lc60/b0;->c:Ljava/lang/String;
+
+    if-eqz v3, :done
+
+    iget-object v10, v4, Lc60/b0;->g:Ljava/lang/String;
+
+    invoke-static {v10}, Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$a;->a(Ljava/lang/String;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;
+
+    move-result-object v4
+
+    invoke-static {v2, v3, v6, v4}, Lcom/aspiro/wamp/playqueue/source/model/b;->j(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v9
+
+    if-eqz v9, :done
+
+    invoke-virtual {v9, v7}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v1, v7, v8, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
@@ -39,8 +39,8 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
-    .locals 7
+.method public invoke(I)Ljava/lang/Object;
+    .locals 8
 
     iget-wide v1, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
 
@@ -73,15 +73,29 @@
 
     iget-wide v4, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
 
-    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicTrackQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+    move v6, p1
+
+    invoke-direct/range {v0 .. v6}, Lradiant/swipe/DynamicTrackQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;JI)V
 
     :emit
-    iget-object v6, p0, Lradiant/swipe/DynamicTrackQueueAction;->callback:Lam0/l;
+    iget-object v7, p0, Lradiant/swipe/DynamicTrackQueueAction;->callback:Lam0/l;
 
-    invoke-interface {v6, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    invoke-interface {v7, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/DynamicTrackQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
@@ -1,0 +1,95 @@
+.class public final Lradiant/swipe/DynamicTrackQueueAction;
+.super Ljava/lang/Object;
+.source "DynamicTrackQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final moduleUuid:Ljava/lang/String;
+
+.field private final pageId:Ljava/lang/String;
+
+.field private final trackId:J
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$e;)V
+    .locals 2
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/DynamicTrackQueueAction;->callback:Lam0/l;
+
+    iput-object p2, p0, Lradiant/swipe/DynamicTrackQueueAction;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/DynamicTrackQueueAction;->moduleUuid:Ljava/lang/String;
+
+    iget-wide v0, p4, Lm40/e$e;->a:J
+
+    iput-wide v0, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 7
+
+    iget-wide v1, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v0
+
+    if-nez v0, :active_queue
+
+    new-instance v0, Lcom/tidal/android/dynamicpages/ui/modules/tracklist/b$a;
+
+    iget-object v3, p0, Lradiant/swipe/DynamicTrackQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v4, p0, Lradiant/swipe/DynamicTrackQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-direct {v0, v1, v2, v3, v4}, Lcom/tidal/android/dynamicpages/ui/modules/tracklist/b$a;-><init>(JLjava/lang/String;Ljava/lang/String;)V
+
+    goto :emit
+
+    :active_queue
+    new-instance v0, Lradiant/swipe/DynamicTrackQueueEvent;
+
+    iget-object v1, p0, Lradiant/swipe/DynamicTrackQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    iget-object v2, p0, Lradiant/swipe/DynamicTrackQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/DynamicTrackQueueAction;->moduleUuid:Ljava/lang/String;
+
+    iget-wide v4, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
+
+    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicTrackQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+
+    :emit
+    iget-object v6, p0, Lradiant/swipe/DynamicTrackQueueAction;->callback:Lam0/l;
+
+    invoke-interface {v6, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/DynamicTrackQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueueAction.smali
@@ -44,6 +44,10 @@
 
     iget-wide v1, p0, Lradiant/swipe/DynamicTrackQueueAction;->trackId:J
 
+    const/4 v0, 0x3
+
+    if-eq p1, v0, :active_queue
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v0

--- a/patches/extension/radiant/swipe/DynamicTrackQueueEvent.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueueEvent.smali
@@ -7,6 +7,8 @@
 
 
 # instance fields
+.field public final action:I
+
 .field public final context:Landroid/content/Context;
 
 .field public final moduleUuid:Ljava/lang/String;
@@ -17,7 +19,7 @@
 
 
 # direct methods
-.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;JI)V
     .locals 0
 
     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
@@ -29,6 +31,8 @@
     iput-object p3, p0, Lradiant/swipe/DynamicTrackQueueEvent;->moduleUuid:Ljava/lang/String;
 
     iput-wide p4, p0, Lradiant/swipe/DynamicTrackQueueEvent;->trackId:J
+
+    iput p6, p0, Lradiant/swipe/DynamicTrackQueueEvent;->action:I
 
     return-void
 .end method

--- a/patches/extension/radiant/swipe/DynamicTrackQueueEvent.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackQueueEvent.smali
@@ -1,0 +1,34 @@
+.class public final Lradiant/swipe/DynamicTrackQueueEvent;
+.super Ljava/lang/Object;
+.source "DynamicTrackQueueEvent.smali"
+
+# interfaces
+.implements Lcom/tidal/android/dynamicpages/ui/modules/tracklist/b;
+
+
+# instance fields
+.field public final context:Landroid/content/Context;
+
+.field public final moduleUuid:Ljava/lang/String;
+
+.field public final pageId:Ljava/lang/String;
+
+.field public final trackId:J
+
+
+# direct methods
+.method public constructor <init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;J)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/DynamicTrackQueueEvent;->context:Landroid/content/Context;
+
+    iput-object p2, p0, Lradiant/swipe/DynamicTrackQueueEvent;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/DynamicTrackQueueEvent;->moduleUuid:Ljava/lang/String;
+
+    iput-wide p4, p0, Lradiant/swipe/DynamicTrackQueueEvent;->trackId:J
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/DynamicTrackResolver.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackResolver.smali
@@ -371,25 +371,6 @@
     return-void
 .end method
 
-.method public isValid(Lradiant/swipe/QueueRequest;)Z
-    .locals 1
-
-    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentTrack(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/Track;
-
-    move-result-object p1
-
-    if-eqz p1, :invalid
-
-    const/4 p1, 0x1
-
-    return p1
-
-    :invalid
-    const/4 p1, 0x0
-
-    return p1
-.end method
-
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
     .locals 5
 
@@ -455,6 +436,8 @@
     check-cast p1, Lo6/b;
 
     iget-object v0, p1, Lo6/b;->c:Lo6/b$a;
+
+    if-eqz v0, :invalid
 
     iget v0, v0, Lo6/b$a;->d:I
 

--- a/patches/extension/radiant/swipe/DynamicTrackResolver.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackResolver.smali
@@ -1,0 +1,477 @@
+.class public final Lradiant/swipe/DynamicTrackResolver;
+.super Ljava/lang/Object;
+.source "DynamicTrackResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final recycler:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private currentRow(Lradiant/swipe/QueueRequest;)Lo6/b;
+    .locals 8
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lo6/b;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lo6/b;
+
+    iget-object v1, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v1, :invalid
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object v2
+
+    instance-of v1, v2, Lcom/tidal/android/core/adapterdelegate/c;
+
+    if-eqz v1, :invalid
+
+    check-cast v2, Lcom/tidal/android/core/adapterdelegate/c;
+
+    invoke-virtual {v2}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v2
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v3, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v2}, Ljava/util/List;->size()I
+
+    move-result v4
+
+    if-lt v3, v4, :read_row
+
+    goto :invalid
+
+    :read_row
+    invoke-interface {v2, v3}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v2
+
+    instance-of v3, v2, Lo6/b;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, Lo6/b;
+
+    iget-object v3, v0, Lo6/b;->a:Lo6/i;
+
+    iget-object v4, v2, Lo6/b;->a:Lo6/i;
+
+    if-ne v3, v4, :invalid
+
+    iget-wide v3, v0, Lo6/b;->b:J
+
+    iget-wide v5, v2, Lo6/b;->b:J
+
+    cmp-long v7, v3, v5
+
+    if-nez v7, :invalid
+
+    iget-object v3, v0, Lo6/b;->c:Lo6/b$a;
+
+    iget-object v4, v2, Lo6/b;->c:Lo6/b$a;
+
+    if-eqz v3, :invalid
+
+    if-eqz v4, :invalid
+
+    iget v5, v3, Lo6/b$a;->d:I
+
+    iget v6, v4, Lo6/b$a;->d:I
+
+    iget v7, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v5, v7, :invalid
+
+    if-ne v6, v7, :invalid
+
+    iget v5, v3, Lo6/b$a;->o:I
+
+    iget v6, v4, Lo6/b$a;->o:I
+
+    if-ne v5, v6, :invalid
+
+    iget-object v5, v3, Lo6/b$a;->q:Ljava/lang/String;
+
+    iget-object v6, v4, Lo6/b$a;->q:Ljava/lang/String;
+
+    if-eq v5, v6, :valid
+
+    if-eqz v5, :invalid
+
+    invoke-virtual {v5, v6}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v5
+
+    if-eqz v5, :invalid
+
+    :valid
+    return-object v2
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method private currentTrack(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/Track;
+    .locals 7
+
+    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentRow(Lradiant/swipe/QueueRequest;)Lo6/b;
+
+    move-result-object v0
+
+    if-eqz v0, :invalid
+
+    iget-object v1, v0, Lo6/b;->a:Lo6/i;
+
+    iget-object v2, v0, Lo6/b;->c:Lo6/b$a;
+
+    iget-object v3, v1, Lo6/i;->p:Ljava/util/LinkedHashMap;
+
+    iget-object v4, v2, Lo6/b$a;->q:Ljava/lang/String;
+
+    invoke-virtual {v3, v4}, Ljava/util/LinkedHashMap;->get(Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v3
+
+    instance-of v4, v3, Lcom/aspiro/wamp/dynamicpages/data/model/collection/TrackCollectionModule;
+
+    if-eqz v4, :invalid
+
+    check-cast v3, Lcom/aspiro/wamp/dynamicpages/data/model/collection/TrackCollectionModule;
+
+    invoke-virtual {v3}, Lcom/aspiro/wamp/dynamicpages/data/model/collection/MediaItemCollectionModule;->getFilteredPagedListItems()Ljava/util/List;
+
+    move-result-object v3
+
+    iget v4, v2, Lo6/b$a;->o:I
+
+    if-gez v4, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v3}, Ljava/util/List;->size()I
+
+    move-result v5
+
+    if-lt v4, v5, :read_track
+
+    goto :invalid
+
+    :read_track
+    invoke-interface {v3, v4}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v3
+
+    instance-of v4, v3, Lcom/aspiro/wamp/model/Track;
+
+    if-eqz v4, :invalid
+
+    check-cast v3, Lcom/aspiro/wamp/model/Track;
+
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v4
+
+    iget v5, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v4, v5, :invalid
+
+    iget-object v1, v1, Lo6/i;->g:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    invoke-interface {v1, v3}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/MediaItem;)Lcom/aspiro/wamp/model/Availability$MediaItem;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+
+    move-result v1
+
+    if-eqz v1, :invalid
+
+    return-object v3
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    new-instance v0, Lradiant/swipe/DynamicTrackResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/DynamicTrackResolver;-><init>(Landroidx/recyclerview/widget/RecyclerView;)V
+
+    invoke-static {p0, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 8
+
+    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentRow(Lradiant/swipe/QueueRequest;)Lo6/b;
+
+    move-result-object v0
+
+    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentTrack(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v1
+
+    if-eqz v0, :done
+
+    if-eqz v1, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v2
+
+    if-nez v2, :append
+
+    iget-object v2, v0, Lo6/b;->a:Lo6/i;
+
+    iget-object v3, v0, Lo6/b;->c:Lo6/b$a;
+
+    iget v4, v3, Lo6/b$a;->o:I
+
+    iget-object v5, v3, Lo6/b$a;->q:Ljava/lang/String;
+
+    invoke-virtual {v2, v4, v5}, Lo6/i;->e(ILjava/lang/String;)V
+
+    goto :done
+
+    :append
+    iget-object v0, v0, Lo6/b;->a:Lo6/i;
+
+    iget-object v2, v0, Lo6/i;->p:Ljava/util/LinkedHashMap;
+
+    iget-object v3, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    check-cast v3, Lo6/b;
+
+    iget-object v3, v3, Lo6/b;->c:Lo6/b$a;
+
+    iget-object v3, v3, Lo6/b$a;->q:Ljava/lang/String;
+
+    invoke-virtual {v2, v3}, Ljava/util/LinkedHashMap;->get(Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v2
+
+    check-cast v2, Lcom/aspiro/wamp/dynamicpages/data/model/collection/TrackCollectionModule;
+
+    new-instance v3, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getPageId()Ljava/lang/String;
+
+    move-result-object v4
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getId()Ljava/lang/String;
+
+    move-result-object v5
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getPosition()I
+
+    move-result v6
+
+    invoke-static {v6}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v6
+
+    invoke-direct {v3, v4, v5, v6}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v4
+
+    invoke-static {v4}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v4
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getTitle()Ljava/lang/String;
+
+    move-result-object v5
+
+    iget-object v6, v0, Lo6/i;->m:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/dynamicpages/data/model/Module;->getSelfLink()Ljava/lang/String;
+
+    move-result-object v7
+
+    invoke-static {v7}, Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$a;->a(Ljava/lang/String;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;
+
+    move-result-object v7
+
+    invoke-static {v4, v5, v6, v7}, Lcom/aspiro/wamp/playqueue/source/model/b;->j(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v4
+
+    invoke-virtual {v4, v1}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    iget-object v5, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v5}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v5
+
+    check-cast v5, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v5, :done
+
+    invoke-virtual {v5}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v5
+
+    invoke-static {v5, v1, v3, v4}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method
+
+.method public isValid(Lradiant/swipe/QueueRequest;)Z
+    .locals 1
+
+    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentTrack(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object p1
+
+    if-eqz p1, :invalid
+
+    const/4 p1, 0x1
+
+    return p1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of v0, p2, Lp7/a$a;
+
+    if-eqz v0, :invalid
+
+    iget-object v0, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    if-ne v0, p1, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lcom/tidal/android/core/adapterdelegate/c;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lcom/tidal/android/core/adapterdelegate/c;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    if-gez p2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_row
+
+    goto :invalid
+
+    :read_row
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lo6/b;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lo6/b;
+
+    iget-object v0, p1, Lo6/b;->c:Lo6/b$a;
+
+    iget v0, v0, Lo6/b$a;->d:I
+
+    new-instance v1, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v1, p2, p1, v0}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    invoke-direct {p0, v1}, Lradiant/swipe/DynamicTrackResolver;->currentTrack(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object p1
+
+    if-eqz p1, :invalid
+
+    return-object v1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/DynamicTrackResolver.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackResolver.smali
@@ -472,7 +472,9 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 8
+    .locals 9
+
+    iget v8, p1, Lradiant/swipe/QueueRequest;->action:I
 
     iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
 
@@ -506,7 +508,7 @@
 
     invoke-virtual {v1, v2}, Lradiant/swipe/AlbumItemQueueAction;->setContext(Landroid/content/Context;)V
 
-    invoke-virtual {v1}, Lradiant/swipe/AlbumItemQueueAction;->invoke()Ljava/lang/Object;
+    invoke-virtual {v1, v8}, Lradiant/swipe/AlbumItemQueueAction;->invoke(I)Ljava/lang/Object;
 
     return-void
 
@@ -622,6 +624,15 @@
 
     move-result-object v5
 
+    const/4 v0, 0x1
+
+    if-ne v8, v0, :append_track
+
+    invoke-static {v5, v1, v3, v4}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v5, v1, v3, v4}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done

--- a/patches/extension/radiant/swipe/DynamicTrackResolver.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackResolver.smali
@@ -525,6 +525,10 @@
 
     if-eqz v1, :done
 
+    const/4 v2, 0x3
+
+    if-eq v8, v2, :append
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v2
@@ -626,9 +630,18 @@
 
     const/4 v0, 0x1
 
-    if-ne v8, v0, :append_track
+    if-ne v8, v0, :check_add_to_playlist
 
     invoke-static {v5, v1, v3, v4}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_to_playlist
+    const/4 v0, 0x3
+
+    if-ne v8, v0, :append_track
+
+    invoke-static {v5, v1, v3, v4}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/DynamicTrackResolver.smali
+++ b/patches/extension/radiant/swipe/DynamicTrackResolver.smali
@@ -11,6 +11,136 @@
 
 
 # direct methods
+.method private currentAlbumRow(Lradiant/swipe/QueueRequest;)Lu5/b$a;
+    .locals 9
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lu5/b$a;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lu5/b$a;
+
+    iget-object v1, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v1, :invalid
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object v2
+
+    instance-of v1, v2, Lcom/tidal/android/core/adapterdelegate/c;
+
+    if-eqz v1, :invalid
+
+    check-cast v2, Lcom/tidal/android/core/adapterdelegate/c;
+
+    invoke-virtual {v2}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v2
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v3, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v2}, Ljava/util/List;->size()I
+
+    move-result v4
+
+    if-lt v3, v4, :read_row
+
+    goto :invalid
+
+    :read_row
+    invoke-interface {v2, v3}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v2
+
+    instance-of v3, v2, Lu5/b$a;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, Lu5/b$a;
+
+    iget-object v3, v0, Lu5/b$a;->a:Lu5/b$a$a;
+
+    iget-object v4, v2, Lu5/b$a;->a:Lu5/b$a$a;
+
+    if-ne v3, v4, :invalid
+
+    iget-wide v3, v0, Lu5/b$a;->b:J
+
+    iget-wide v5, v2, Lu5/b$a;->b:J
+
+    cmp-long v7, v3, v5
+
+    if-nez v7, :invalid
+
+    iget-object v3, v0, Lu5/b$a;->c:Lu5/b$a$b;
+
+    iget-object v4, v2, Lu5/b$a;->c:Lu5/b$a$b;
+
+    if-eqz v3, :invalid
+
+    if-eqz v4, :invalid
+
+    iget v5, v3, Lu5/b$a$b;->r:I
+
+    iget v6, v4, Lu5/b$a$b;->r:I
+
+    iget v7, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v5, v7, :invalid
+
+    if-ne v6, v7, :invalid
+
+    iget-object v5, v3, Lu5/b$a$b;->s:Ljava/lang/String;
+
+    iget-object v6, v4, Lu5/b$a$b;->s:Ljava/lang/String;
+
+    if-eq v5, v6, :module_valid
+
+    if-eqz v5, :invalid
+
+    invoke-virtual {v5, v6}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v5
+
+    if-eqz v5, :invalid
+
+    :module_valid
+    iget-object v5, v4, Lu5/b$a$b;->g:Lcom/aspiro/wamp/model/Availability;
+
+    invoke-interface {v5}, Lcom/aspiro/wamp/model/Availability;->isAvailable()Z
+
+    move-result v5
+
+    if-eqz v5, :invalid
+
+    iget-boolean v5, v4, Lu5/b$a$b;->p:Z
+
+    if-nez v5, :invalid
+
+    return-object v2
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
 .method private constructor <init>(Landroidx/recyclerview/widget/RecyclerView;)V
     .locals 1
 
@@ -234,6 +364,96 @@
     return-object v0
 .end method
 
+.method private resolveAlbum(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    iget-object v0, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    if-ne v0, p1, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lcom/tidal/android/core/adapterdelegate/c;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lcom/tidal/android/core/adapterdelegate/c;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    if-gez p2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_row
+
+    goto :invalid
+
+    :read_row
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lu5/b$a;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lu5/b$a;
+
+    iget-object v0, p1, Lu5/b$a;->c:Lu5/b$a$b;
+
+    if-eqz v0, :invalid
+
+    iget-object v1, v0, Lu5/b$a$b;->g:Lcom/aspiro/wamp/model/Availability;
+
+    invoke-interface {v1}, Lcom/aspiro/wamp/model/Availability;->isAvailable()Z
+
+    move-result v1
+
+    if-eqz v1, :invalid
+
+    iget-boolean v1, v0, Lu5/b$a$b;->p:Z
+
+    if-nez v1, :invalid
+
+    iget v0, v0, Lu5/b$a$b;->r:I
+
+    new-instance v1, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v1, p2, p1, v0}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method
+
 .method public static install(Landroidx/recyclerview/widget/RecyclerView;)V
     .locals 1
 
@@ -254,6 +474,43 @@
 .method public execute(Lradiant/swipe/QueueRequest;)V
     .locals 8
 
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lu5/b$a;
+
+    if-eqz v1, :dynamic_track
+
+    invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentAlbumRow(Lradiant/swipe/QueueRequest;)Lu5/b$a;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    new-instance v1, Lradiant/swipe/AlbumItemQueueAction;
+
+    invoke-direct {v1, v0}, Lradiant/swipe/AlbumItemQueueAction;-><init>(Lu5/b$a;)V
+
+    iget-object v2, p0, Lradiant/swipe/DynamicTrackResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v2
+
+    check-cast v2, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v2, :done
+
+    invoke-virtual {v2}, Landroid/view/View;->getContext()Landroid/content/Context;
+
+    move-result-object v2
+
+    invoke-virtual {v1, v2}, Lradiant/swipe/AlbumItemQueueAction;->setContext(Landroid/content/Context;)V
+
+    invoke-virtual {v1}, Lradiant/swipe/AlbumItemQueueAction;->invoke()Ljava/lang/Object;
+
+    return-void
+
+    :dynamic_track
     invoke-direct {p0, p1}, Lradiant/swipe/DynamicTrackResolver;->currentRow(Lradiant/swipe/QueueRequest;)Lo6/b;
 
     move-result-object v0
@@ -374,6 +631,17 @@
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
     .locals 5
 
+    instance-of v0, p2, Lv6/e$a;
+
+    if-eqz v0, :dynamic_holder
+
+    invoke-direct {p0, p1, p2}, Lradiant/swipe/DynamicTrackResolver;->resolveAlbum(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+
+    move-result-object p1
+
+    return-object p1
+
+    :dynamic_holder
     instance-of v0, p2, Lp7/a$a;
 
     if-eqz v0, :invalid

--- a/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
+++ b/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
@@ -1,0 +1,181 @@
+.class public final Lradiant/swipe/FavoriteTracksResolver;
+.super Ljava/lang/Object;
+.source "FavoriteTracksResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/FavoriteTracksResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/FavoriteTracksResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 3
+
+    invoke-virtual {p0, p1}, Lradiant/swipe/FavoriteTracksResolver;->isValid(Lradiant/swipe/QueueRequest;)Z
+
+    move-result v0
+
+    if-eqz v0, :done
+
+    iget-object v0, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+
+    if-eqz v0, :done
+
+    iget v1, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    iget-object v2, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    check-cast v2, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    invoke-virtual {v0, v1, v2}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
+
+    :done
+    return-void
+.end method
+
+.method public isValid(Lradiant/swipe/QueueRequest;)Z
+    .locals 4
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v1, :invalid
+
+    iget-object v1, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+
+    if-eqz v1, :invalid
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    check-cast v0, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v3
+
+    iget p1, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v3, p1, :invalid
+
+    invoke-virtual {v1, v2, v0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
+
+    move-result p1
+
+    return p1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of p1, p2, Ln8/d;
+
+    if-eqz p1, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p1
+
+    const/4 v0, -0x1
+
+    if-ne p1, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    check-cast p2, Ln8/d;
+
+    iget-object p2, p2, Ln8/d;->f:Lcom/aspiro/wamp/model/MediaItem;
+
+    instance-of v0, p2, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    if-eqz v0, :invalid
+
+    check-cast p2, Lcom/aspiro/wamp/model/FavoriteTrack;
+
+    iget-object v0, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {v0, p1, p2}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
+
+    move-result v0
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v0
+
+    new-instance v1, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v1, p1, p2, v0}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
+++ b/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
@@ -47,12 +47,6 @@
 .method public execute(Lradiant/swipe/QueueRequest;)V
     .locals 3
 
-    invoke-virtual {p0, p1}, Lradiant/swipe/FavoriteTracksResolver;->isValid(Lradiant/swipe/QueueRequest;)Z
-
-    move-result v0
-
-    if-eqz v0, :done
-
     iget-object v0, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
 
     invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
@@ -73,51 +67,6 @@
 
     :done
     return-void
-.end method
-
-.method public isValid(Lradiant/swipe/QueueRequest;)Z
-    .locals 4
-
-    if-eqz p1, :invalid
-
-    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
-
-    instance-of v1, v0, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    if-eqz v1, :invalid
-
-    iget-object v1, p0, Lradiant/swipe/FavoriteTracksResolver;->fragment:Ljava/lang/ref/WeakReference;
-
-    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
-
-    move-result-object v1
-
-    check-cast v1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;
-
-    if-eqz v1, :invalid
-
-    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
-
-    check-cast v0, Lcom/aspiro/wamp/model/FavoriteTrack;
-
-    invoke-virtual {v0}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
-
-    move-result v3
-
-    iget p1, p1, Lradiant/swipe/QueueRequest;->id:I
-
-    if-ne v3, p1, :invalid
-
-    invoke-virtual {v1, v2, v0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
-
-    move-result p1
-
-    return p1
-
-    :invalid
-    const/4 p1, 0x0
-
-    return p1
 .end method
 
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;

--- a/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
+++ b/patches/extension/radiant/swipe/FavoriteTracksResolver.smali
@@ -63,7 +63,9 @@
 
     check-cast v2, Lcom/aspiro/wamp/model/FavoriteTrack;
 
-    invoke-virtual {v0, v1, v2}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
+    iget p1, p1, Lradiant/swipe/QueueRequest;->action:I
+
+    invoke-virtual {v0, v1, v2, p1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Z(ILcom/aspiro/wamp/model/FavoriteTrack;I)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/FeedResolver.smali
+++ b/patches/extension/radiant/swipe/FeedResolver.smali
@@ -410,6 +410,10 @@
 
     check-cast v7, Lcom/aspiro/wamp/model/Playlist;
 
+    const/4 v0, 0x3
+
+    if-eq p0, v0, :add_to_playlist_playlist
+
     const/4 v0, 0x1
 
     if-ne p0, v0, :append_playlist
@@ -420,6 +424,11 @@
 
     :append_playlist
     invoke-static {v3, v7, p1, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :add_to_playlist_playlist
+    invoke-static {v3, v7, p1, v5}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
 
@@ -438,6 +447,10 @@
 
     check-cast v7, Lcom/aspiro/wamp/model/Album;
 
+    const/4 v0, 0x3
+
+    if-eq p0, v0, :add_to_playlist_album
+
     const/4 v0, 0x1
 
     if-ne p0, v0, :append_album
@@ -455,8 +468,17 @@
 
     goto :retain
 
+    :add_to_playlist_album
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+
+    goto :done
+
     :queue_mix
     check-cast v7, Lcom/aspiro/wamp/mix/model/Mix;
+
+    const/4 v0, 0x3
+
+    if-eq p0, v0, :add_to_playlist_mix
 
     const/4 v0, 0x1
 
@@ -472,6 +494,13 @@
     invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object v7
+
+    goto :retain
+
+    :add_to_playlist_mix
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+
+    goto :done
 
     :retain
     if-eqz v7, :done

--- a/patches/extension/radiant/swipe/FeedResolver.smali
+++ b/patches/extension/radiant/swipe/FeedResolver.smali
@@ -1,0 +1,605 @@
+.class public final Lradiant/swipe/FeedResolver;
+.super Ljava/lang/Object;
+.source "FeedResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+.field private final recycler:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/tidal/android/feature/feed/ui/FeedView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/FeedResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p2}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/FeedResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private availabilityInteractor()Lcom/aspiro/wamp/model/AvailabilityInteractor;
+    .locals 2
+
+    iget-object v0, p0, Lradiant/swipe/FeedResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/tidal/android/feature/feed/ui/FeedView;
+
+    if-eqz v0, :invalid
+
+    iget-object v0, v0, Lcom/tidal/android/feature/feed/ui/FeedView;->d:Lv70/b;
+
+    instance-of v1, v0, Lcom/tidal/android/feature/feed/ui/c;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/tidal/android/feature/feed/ui/c;
+
+    iget-object v0, v0, Lcom/tidal/android/feature/feed/ui/c;->c:Lz70/a;
+
+    if-eqz v0, :invalid
+
+    iget-object v0, v0, Lz70/a;->c:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    .locals 10
+
+    if-eqz p1, :invalid
+
+    iget-object v8, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    iget-object v0, p0, Lradiant/swipe/FeedResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/tidal/android/feature/feed/ui/FeedView;
+
+    if-eqz v0, :invalid
+
+    iget-object v1, p0, Lradiant/swipe/FeedResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v1, :invalid
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object v2
+
+    instance-of v3, v2, La50/b;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, La50/b;
+
+    iget-object v2, v2, La50/b;->b:Ljava/util/ArrayList;
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v3, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-virtual {v2}, Ljava/util/ArrayList;->size()I
+
+    move-result v4
+
+    if-lt v3, v4, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-virtual {v2, v3}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+
+    move-result-object v2
+
+    invoke-direct {p0}, Lradiant/swipe/FeedResolver;->availabilityInteractor()Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    move-result-object v4
+
+    if-eqz v4, :invalid
+
+    instance-of v3, v2, Lb80/a;
+
+    if-eqz v3, :mix
+
+    instance-of v3, v8, Lcom/aspiro/wamp/model/Album;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, Lb80/a;
+
+    iget-boolean v3, v2, Lb80/a;->c:Z
+
+    if-eqz v3, :invalid
+
+    check-cast v8, Lcom/aspiro/wamp/model/Album;
+
+    iget-object v5, v2, Lb80/a;->a:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v8}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v6
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v7
+
+    if-ne v6, v7, :invalid
+
+    iget v6, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v7, v6, :invalid
+
+    invoke-interface {v4, v5}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/Album;)Lcom/aspiro/wamp/model/Availability$Album;
+
+    move-result-object v4
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$Album;->isAvailable()Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    return-object v2
+
+    :mix
+    instance-of v3, v2, Lb80/c;
+
+    if-eqz v3, :playlist
+
+    instance-of v3, v8, Lcom/aspiro/wamp/mix/model/Mix;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, Lb80/c;
+
+    check-cast v8, Lcom/aspiro/wamp/mix/model/Mix;
+
+    iget-object v5, v2, Lb80/c;->a:Lcom/aspiro/wamp/mix/model/Mix;
+
+    invoke-virtual {v8}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v6
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v7
+
+    invoke-virtual {v6, v7}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v6
+
+    if-eqz v6, :invalid
+
+    invoke-virtual {v7}, Ljava/lang/String;->hashCode()I
+
+    move-result v6
+
+    iget v8, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v6, v8, :invalid
+
+    invoke-interface {v4, v7}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getMixAvailability(Ljava/lang/String;)Lcom/aspiro/wamp/model/Availability$Mix;
+
+    move-result-object v4
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$Mix;->isAvailable()Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    return-object v2
+
+    :playlist
+    instance-of v3, v2, Lb80/d;
+
+    if-eqz v3, :invalid
+
+    instance-of v3, v8, Lcom/aspiro/wamp/model/Playlist;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, Lb80/d;
+
+    check-cast v8, Lcom/aspiro/wamp/model/Playlist;
+
+    iget-object v5, v2, Lb80/d;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v8}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v6
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v7
+
+    invoke-virtual {v6, v7}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v6
+
+    if-eqz v6, :invalid
+
+    invoke-virtual {v7}, Ljava/lang/String;->hashCode()I
+
+    move-result v6
+
+    iget v8, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v6, v8, :invalid
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v6
+
+    if-lez v6, :invalid
+
+    const-string v6, "NOT_READY"
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/Playlist;->getStatus()Ljava/lang/String;
+
+    move-result-object v8
+
+    invoke-virtual {v6, v8}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v6
+
+    if-nez v6, :invalid
+
+    invoke-static {v7}, Ljava/util/UUID;->fromString(Ljava/lang/String;)Ljava/util/UUID;
+
+    move-result-object v6
+
+    invoke-interface {v4, v6}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getPlaylistAvailability(Ljava/util/UUID;)Lcom/aspiro/wamp/model/Availability$Playlist;
+
+    move-result-object v4
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$Playlist;->isAvailable()Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    return-object v2
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/tidal/android/feature/feed/ui/FeedView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/FeedResolver;
+
+    invoke-direct {v0, p0, p1}, Lradiant/swipe/FeedResolver;-><init>(Lcom/tidal/android/feature/feed/ui/FeedView;Landroidx/recyclerview/widget/RecyclerView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 9
+
+    invoke-direct {p0, p1}, Lradiant/swipe/FeedResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    iget-object v1, p0, Lradiant/swipe/FeedResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/tidal/android/feature/feed/ui/FeedView;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v3
+
+    if-eqz v3, :done
+
+    iget-object v2, v1, Lcom/tidal/android/feature/feed/ui/FeedView;->c:La80/c;
+
+    if-eqz v2, :done
+
+    instance-of v4, v0, Lb80/a;
+
+    if-eqz v4, :mix
+
+    check-cast v0, Lb80/a;
+
+    iget-object v7, v0, Lb80/a;->a:Lcom/aspiro/wamp/model/Album;
+
+    iget v8, v0, Lb80/a;->g:I
+
+    const/4 v4, 0x1
+
+    goto :metadata
+
+    :mix
+    instance-of v4, v0, Lb80/c;
+
+    if-eqz v4, :playlist
+
+    check-cast v0, Lb80/c;
+
+    iget-object v7, v0, Lb80/c;->a:Lcom/aspiro/wamp/mix/model/Mix;
+
+    iget v8, v0, Lb80/c;->c:I
+
+    const/4 v4, 0x2
+
+    goto :metadata
+
+    :playlist
+    check-cast v0, Lb80/d;
+
+    iget-object v7, v0, Lb80/d;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    iget v8, v0, Lb80/d;->c:I
+
+    const/4 v4, 0x3
+
+    :metadata
+    invoke-static {v8}, Lcom/tidal/android/feature/feed/ui/viewstates/UpdatedIntervals$a;->a(I)Ljava/lang/String;
+
+    move-result-object v8
+
+    iget-object v0, v2, La80/c;->a:Ljava/lang/String;
+
+    new-instance p1, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    invoke-direct {p1, v0, v8}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;)V
+
+    iget-object v5, v2, La80/c;->e:Lcom/tidal/android/navigation/NavigationInfo;
+
+    const/4 v0, 0x3
+
+    if-ne v4, v0, :collection
+
+    check-cast v7, Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-static {v3, v7, p1, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :collection
+    iget-object v6, v2, La80/c;->b:Lx40/a;
+
+    instance-of v0, v6, Lh4/a;
+
+    if-eqz v0, :done
+
+    check-cast v6, Lh4/a;
+
+    const/4 v0, 0x1
+
+    if-ne v4, v0, :queue_mix
+
+    check-cast v7, Lcom/aspiro/wamp/model/Album;
+
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v7
+
+    goto :retain
+
+    :queue_mix
+    check-cast v7, Lcom/aspiro/wamp/mix/model/Mix;
+
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v7
+
+    :retain
+    if-eqz v7, :done
+
+    iget-object v0, v1, Lcom/tidal/android/feature/feed/ui/FeedView;->f:Lio/reactivex/disposables/CompositeDisposable;
+
+    invoke-virtual {v0, v7}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 7
+
+    iget-object v0, p0, Lradiant/swipe/FeedResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    if-ne v0, p1, :invalid
+
+    instance-of v0, p2, Lw70/c$a;
+
+    if-eqz v0, :mix_holder
+
+    const/4 v5, 0x1
+
+    goto :has_holder
+
+    :mix_holder
+
+    instance-of v0, p2, Lw70/h$a;
+
+    if-eqz v0, :playlist_holder
+
+    const/4 v5, 0x2
+
+    goto :has_holder
+
+    :playlist_holder
+
+    instance-of v0, p2, Lw70/k$a;
+
+    if-eqz v0, :invalid
+
+    const/4 v5, 0x3
+
+    :has_holder
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    if-gez p2, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/b;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/b;
+
+    iget-object p1, p1, La50/b;->b:Ljava/util/ArrayList;
+
+    invoke-virtual {p1}, Ljava/util/ArrayList;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-virtual {p1, p2}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lb80/a;
+
+    if-eqz v0, :mix
+
+    const/4 v0, 0x1
+
+    if-ne v5, v0, :invalid
+
+    check-cast p1, Lb80/a;
+
+    iget-object v1, p1, Lb80/a;->a:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v2
+
+    goto :request
+
+    :mix
+    instance-of v0, p1, Lb80/c;
+
+    if-eqz v0, :playlist
+
+    const/4 v0, 0x2
+
+    if-ne v5, v0, :invalid
+
+    check-cast p1, Lb80/c;
+
+    iget-object v1, p1, Lb80/c;->a:Lcom/aspiro/wamp/mix/model/Mix;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    goto :request
+
+    :playlist
+    instance-of v0, p1, Lb80/d;
+
+    if-eqz v0, :invalid
+
+    const/4 v0, 0x3
+
+    if-ne v5, v0, :invalid
+
+    check-cast p1, Lb80/d;
+
+    iget-object v1, p1, Lb80/d;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    :request
+    new-instance v3, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v3, p2, v1, v2}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    invoke-direct {p0, v3}, Lradiant/swipe/FeedResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+
+    move-result-object v4
+
+    if-eqz v4, :invalid
+
+    return-object v3
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/FeedResolver.smali
+++ b/patches/extension/radiant/swipe/FeedResolver.smali
@@ -333,6 +333,8 @@
 
     iget-object v1, p0, Lradiant/swipe/FeedResolver;->fragment:Ljava/lang/ref/WeakReference;
 
+    iget p0, p1, Lradiant/swipe/QueueRequest;->action:I
+
     invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
 
     move-result-object v1
@@ -408,6 +410,15 @@
 
     check-cast v7, Lcom/aspiro/wamp/model/Playlist;
 
+    const/4 v0, 0x1
+
+    if-ne p0, v0, :append_playlist
+
+    invoke-static {v3, v7, p1, v5}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v3, v7, p1, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     goto :done
@@ -427,6 +438,17 @@
 
     check-cast v7, Lcom/aspiro/wamp/model/Album;
 
+    const/4 v0, 0x1
+
+    if-ne p0, v0, :append_album
+
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v7
+
+    goto :retain
+
+    :append_album
     invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object v7
@@ -436,6 +458,17 @@
     :queue_mix
     check-cast v7, Lcom/aspiro/wamp/mix/model/Mix;
 
+    const/4 v0, 0x1
+
+    if-ne p0, v0, :append_mix
+
+    invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v7
+
+    goto :retain
+
+    :append_mix
     invoke-static {v3, v7, p1, v5, v6}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object v7

--- a/patches/extension/radiant/swipe/MyAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/MyAlbumsResolver.smali
@@ -162,6 +162,10 @@
 
     iget-object p0, v1, Lfd/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
+    const/4 v1, 0x3
+
+    if-eq v6, v1, :add_to_playlist
+
     const/4 v1, 0x1
 
     if-ne v6, v1, :append
@@ -176,6 +180,13 @@
     invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
+
+    goto :retain
+
+    :add_to_playlist
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+
+    goto :done
 
     :retain
     if-eqz p1, :done

--- a/patches/extension/radiant/swipe/MyAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/MyAlbumsResolver.smali
@@ -1,0 +1,267 @@
+.class public final Lradiant/swipe/MyAlbumsResolver;
+.super Ljava/lang/Object;
+.source "MyAlbumsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/MyAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lzc/a;
+    .locals 7
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p0, Lradiant/swipe/MyAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;
+
+    if-eqz v0, :invalid
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;->h:Lad/f;
+
+    if-eqz v1, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;->N()La50/d;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v0
+
+    iget v1, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v1, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v0}, Ljava/util/List;->size()I
+
+    move-result v2
+
+    if-lt v1, v2, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {v0, v1}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v0
+
+    instance-of v1, v0, Lzc/a;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lzc/a;
+
+    iget-boolean v1, v0, Lzc/a;->k:Z
+
+    if-eqz v1, :invalid
+
+    iget-object v1, v0, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v1, v2, :invalid
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/MyAlbumsResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/MyAlbumsResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 7
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, p0, Lradiant/swipe/MyAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;
+
+    if-eqz v0, :done
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;->c:Lfd/c;
+
+    if-eqz v1, :done
+
+    iget-object v2, v1, Lfd/c;->a:Lx40/a;
+
+    instance-of v3, v2, Lh4/a;
+
+    if-eqz v3, :done
+
+    check-cast v2, Lh4/a;
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v3
+
+    iget-object v4, p1, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    iget-object v5, v1, Lfd/c;->d:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v6, v1, Lfd/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;->j:Lio/reactivex/disposables/CompositeDisposable;
+
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    :done
+    return-void
+.end method
+
+.method public isValid(Lradiant/swipe/QueueRequest;)Z
+    .locals 1
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
+
+    move-result-object p1
+
+    if-eqz p1, :invalid
+
+    const/4 p1, 0x1
+
+    return p1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 6
+
+    instance-of v0, p2, Lbd/d$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/d;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/d;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lzc/a;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lzc/a;
+
+    iget-boolean v0, p1, Lzc/a;->k:Z
+
+    if-eqz v0, :invalid
+
+    iget-object v0, p1, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v1
+
+    new-instance v2, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v2, p2, v0, v1}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v2
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/MyAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/MyAlbumsResolver.smali
@@ -122,6 +122,8 @@
 .method public execute(Lradiant/swipe/QueueRequest;)V
     .locals 7
 
+    iget v6, p1, Lradiant/swipe/QueueRequest;->action:I
+
     invoke-direct {p0, p1}, Lradiant/swipe/MyAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
 
     move-result-object p1
@@ -158,12 +160,24 @@
 
     iget-object v5, v1, Lfd/c;->d:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
 
-    iget-object v6, v1, Lfd/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+    iget-object p0, v1, Lfd/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
-    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    const/4 v1, 0x1
+
+    if-ne v6, v1, :append
+
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
 
+    goto :retain
+
+    :append
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    :retain
     if-eqz p1, :done
 
     iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;->j:Lio/reactivex/disposables/CompositeDisposable;

--- a/patches/extension/radiant/swipe/MyAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/MyAlbumsResolver.smali
@@ -174,25 +174,6 @@
     return-void
 .end method
 
-.method public isValid(Lradiant/swipe/QueueRequest;)Z
-    .locals 1
-
-    invoke-direct {p0, p1}, Lradiant/swipe/MyAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
-
-    move-result-object p1
-
-    if-eqz p1, :invalid
-
-    const/4 p1, 0x1
-
-    return p1
-
-    :invalid
-    const/4 p1, 0x0
-
-    return p1
-.end method
-
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
     .locals 6
 

--- a/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
+++ b/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
@@ -198,6 +198,10 @@
 
     iget-object p0, v1, Lpe/f;->b:Lcom/tidal/android/navigation/NavigationInfo;
 
+    const/4 v1, 0x3
+
+    if-eq v7, v1, :add_to_playlist
+
     const/4 v1, 0x1
 
     if-ne v7, v1, :append
@@ -212,6 +216,13 @@
     invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
+
+    goto :retain
+
+    :add_to_playlist
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+
+    goto :done
 
     :retain
     if-eqz p1, :done

--- a/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
+++ b/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
@@ -152,7 +152,9 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 7
+    .locals 8
+
+    iget v7, p1, Lradiant/swipe/QueueRequest;->action:I
 
     invoke-direct {p0, p1}, Lradiant/swipe/MyMixesAndRadioResolver;->current(Lradiant/swipe/QueueRequest;)Lve/a;
 
@@ -194,12 +196,24 @@
 
     invoke-direct {v5, v6}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;)V
 
-    iget-object v6, v1, Lpe/f;->b:Lcom/tidal/android/navigation/NavigationInfo;
+    iget-object p0, v1, Lpe/f;->b:Lcom/tidal/android/navigation/NavigationInfo;
 
-    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    const/4 v1, 0x1
+
+    if-ne v7, v1, :append
+
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
 
+    goto :retain
+
+    :append
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    :retain
     if-eqz p1, :done
 
     iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;->h:Lio/reactivex/disposables/CompositeDisposable;

--- a/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
+++ b/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
@@ -210,25 +210,6 @@
     return-void
 .end method
 
-.method public isValid(Lradiant/swipe/QueueRequest;)Z
-    .locals 1
-
-    invoke-direct {p0, p1}, Lradiant/swipe/MyMixesAndRadioResolver;->current(Lradiant/swipe/QueueRequest;)Lve/a;
-
-    move-result-object p1
-
-    if-eqz p1, :invalid
-
-    const/4 p1, 0x1
-
-    return p1
-
-    :invalid
-    const/4 p1, 0x0
-
-    return p1
-.end method
-
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
     .locals 5
 

--- a/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
+++ b/patches/extension/radiant/swipe/MyMixesAndRadioResolver.smali
@@ -1,0 +1,322 @@
+.class public final Lradiant/swipe/MyMixesAndRadioResolver;
+.super Ljava/lang/Object;
+.source "MyMixesAndRadioResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/MyMixesAndRadioResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lve/a;
+    .locals 6
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lcom/aspiro/wamp/mix/model/Mix;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/mix/model/Mix;
+
+    iget-object v1, p0, Lradiant/swipe/MyMixesAndRadioResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;
+
+    if-eqz v1, :invalid
+
+    iget-object v2, v1, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;->c:Lpe/f;
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;->N()La50/d;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    move-result v3
+
+    if-lt v2, v3, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {v1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v2, v1, Lve/a;
+
+    if-eqz v2, :invalid
+
+    check-cast v1, Lve/a;
+
+    iget-boolean v2, v1, Lve/a;->f:Z
+
+    if-eqz v2, :invalid
+
+    iget-object v2, v1, Lve/a;->c:Lcom/aspiro/wamp/mix/model/Mix;
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v0
+
+    iget-object v3, v1, Lve/a;->a:Ljava/lang/String;
+
+    invoke-virtual {v3, v0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v3, v2}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v2
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v3}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v2, v3, :invalid
+
+    return-object v1
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/MyMixesAndRadioResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/MyMixesAndRadioResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 7
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyMixesAndRadioResolver;->current(Lradiant/swipe/QueueRequest;)Lve/a;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, p0, Lradiant/swipe/MyMixesAndRadioResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;
+
+    if-eqz v0, :done
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;->c:Lpe/f;
+
+    if-eqz v1, :done
+
+    iget-object v2, v1, Lpe/f;->a:Lx40/a;
+
+    instance-of v3, v2, Lh4/a;
+
+    if-eqz v3, :done
+
+    check-cast v2, Lh4/a;
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v3
+
+    iget-object v4, p1, Lve/a;->c:Lcom/aspiro/wamp/mix/model/Mix;
+
+    new-instance v5, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    const-string v6, "mycollection_mixes_and_radio"
+
+    invoke-direct {v5, v6}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;)V
+
+    iget-object v6, v1, Lpe/f;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;->h:Lio/reactivex/disposables/CompositeDisposable;
+
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    :done
+    return-void
+.end method
+
+.method public isValid(Lradiant/swipe/QueueRequest;)Z
+    .locals 1
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyMixesAndRadioResolver;->current(Lradiant/swipe/QueueRequest;)Lve/a;
+
+    move-result-object p1
+
+    if-eqz p1, :invalid
+
+    const/4 p1, 0x1
+
+    return p1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of v0, p2, Lqe/c$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/d;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/d;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    if-gez p2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lve/a;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lve/a;
+
+    iget-boolean v0, p1, Lve/a;->f:Z
+
+    if-eqz v0, :invalid
+
+    iget-object v0, p1, Lve/a;->c:Lcom/aspiro/wamp/mix/model/Mix;
+
+    if-eqz v0, :invalid
+
+    iget-object v1, p1, Lve/a;->a:Ljava/lang/String;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v1, v2}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v2
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v1}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    new-instance v3, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v3, p2, v0, v2}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v3
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
@@ -193,25 +193,6 @@
     return-void
 .end method
 
-.method public isValid(Lradiant/swipe/QueueRequest;)Z
-    .locals 1
-
-    invoke-direct {p0, p1}, Lradiant/swipe/MyPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
-
-    move-result-object p1
-
-    if-eqz p1, :invalid
-
-    const/4 p1, 0x1
-
-    return p1
-
-    :invalid
-    const/4 p1, 0x0
-
-    return p1
-.end method
-
 .method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
     .locals 5
 

--- a/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
@@ -189,6 +189,10 @@
 
     iget-object p0, v1, Lhf/c;->d:Lcom/tidal/android/navigation/NavigationInfo;
 
+    const/4 v0, 0x3
+
+    if-eq v5, v0, :add_to_playlist
+
     const/4 v0, 0x1
 
     if-ne v5, v0, :append
@@ -199,6 +203,11 @@
 
     :append
     invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :add_to_playlist
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
@@ -157,6 +157,8 @@
 .method public execute(Lradiant/swipe/QueueRequest;)V
     .locals 6
 
+    iget v5, p1, Lradiant/swipe/QueueRequest;->action:I
+
     invoke-direct {p0, p1}, Lradiant/swipe/MyPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
 
     move-result-object p1
@@ -185,9 +187,18 @@
 
     iget-object v4, v1, Lhf/c;->e:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
 
-    iget-object v5, v1, Lhf/c;->d:Lcom/tidal/android/navigation/NavigationInfo;
+    iget-object p0, v1, Lhf/c;->d:Lcom/tidal/android/navigation/NavigationInfo;
 
-    invoke-static {v2, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    const/4 v0, 0x1
+
+    if-ne v5, v0, :append
+
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/MyPlaylistsResolver.smali
@@ -1,0 +1,311 @@
+.class public final Lradiant/swipe/MyPlaylistsResolver;
+.super Ljava/lang/Object;
+.source "MyPlaylistsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/MyPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lcf/b;
+    .locals 6
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lcom/aspiro/wamp/model/Playlist;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/model/Playlist;
+
+    iget-object v1, p0, Lradiant/swipe/MyPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;
+
+    if-eqz v1, :invalid
+
+    iget-object v2, v1, Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;->j:Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/h;
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;->N()La50/d;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    move-result v3
+
+    if-lt v2, v3, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {v1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v2, v1, Lcf/b;
+
+    if-eqz v2, :invalid
+
+    check-cast v1, Lcf/b;
+
+    iget-boolean v2, v1, Lcf/b;->h:Z
+
+    if-eqz v2, :invalid
+
+    iget-boolean v2, v1, Lcf/b;->f:Z
+
+    if-eqz v2, :check_playlist
+
+    const-string v2, "NOT_READY"
+
+    iget-object v3, v1, Lcf/b;->g:Ljava/lang/String;
+
+    invoke-virtual {v2, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v2
+
+    if-nez v2, :invalid
+
+    :check_playlist
+    iget-object v2, v1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v3
+
+    if-lez v3, :invalid
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-virtual {v2, v0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v0
+
+    if-eqz v0, :invalid
+
+    return-object v1
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/MyPlaylistsResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/MyPlaylistsResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 6
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, p0, Lradiant/swipe/MyPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;
+
+    if-eqz v0, :done
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;->d:Lhf/c;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v2
+
+    iget-object v3, p1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    iget-object v4, v1, Lhf/c;->e:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v5, v1, Lhf/c;->d:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v2, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    :done
+    return-void
+.end method
+
+.method public isValid(Lradiant/swipe/QueueRequest;)Z
+    .locals 1
+
+    invoke-direct {p0, p1}, Lradiant/swipe/MyPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
+
+    move-result-object p1
+
+    if-eqz p1, :invalid
+
+    const/4 p1, 0x1
+
+    return p1
+
+    :invalid
+    const/4 p1, 0x0
+
+    return p1
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of v0, p2, Ldf/d$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/d;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/d;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lcf/b;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lcf/b;
+
+    iget-boolean v0, p1, Lcf/b;->h:Z
+
+    if-eqz v0, :invalid
+
+    iget-boolean v0, p1, Lcf/b;->f:Z
+
+    if-eqz v0, :check_playlist
+
+    const-string v0, "NOT_READY"
+
+    iget-object v1, p1, Lcf/b;->g:Ljava/lang/String;
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v0
+
+    if-nez v0, :invalid
+
+    :check_playlist
+    iget-object v0, p1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v1
+
+    if-lez v1, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    new-instance v3, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v3, p2, v0, v2}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v3
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
+++ b/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
@@ -243,7 +243,9 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 8
+    .locals 9
+
+    iget v8, p1, Lradiant/swipe/QueueRequest;->action:I
 
     invoke-direct {p0, p1}, Lradiant/swipe/PlaylistItemsResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
     move-result-object v0
@@ -301,6 +303,15 @@
     :append
     invoke-virtual {v2}, Landroid/view/View;->getContext()Landroid/content/Context;
     move-result-object v3
+    const/4 v0, 0x1
+
+    if-ne v8, v0, :append_track
+
+    invoke-static {v3, v1, v6, v7}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append_track
     invoke-static {v3, v1, v6, v7}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
     goto :done
 

--- a/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
+++ b/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
@@ -260,10 +260,15 @@
     check-cast v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;
     if-eqz v2, :done
 
+    const/4 v3, 0x3
+
+    if-eq v8, v3, :build_source
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
     move-result v3
     if-eqz v3, :play
 
+    :build_source
     instance-of v3, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
     if-eqz v3, :append_member
 
@@ -303,6 +308,10 @@
     :append
     invoke-virtual {v2}, Landroid/view/View;->getContext()Landroid/content/Context;
     move-result-object v3
+    const/4 v0, 0x3
+
+    if-eq v8, v0, :add_to_playlist
+
     const/4 v0, 0x1
 
     if-ne v8, v0, :append_track
@@ -313,6 +322,10 @@
 
     :append_track
     invoke-static {v3, v1, v6, v7}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    goto :done
+
+    :add_to_playlist
+    invoke-static {v3, v1, v6, v7}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
     goto :done
 
     :play

--- a/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
+++ b/patches/extension/radiant/swipe/PlaylistItemsResolver.smali
@@ -1,0 +1,392 @@
+.class public final Lradiant/swipe/PlaylistItemsResolver;
+.super Ljava/lang/Object;
+.source "PlaylistItemsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+# instance fields
+.field private final recycler:Ljava/lang/ref/WeakReference;
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+    iput-object v0, p0, Lradiant/swipe/PlaylistItemsResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    .locals 7
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    iget-object v1, p0, Lradiant/swipe/PlaylistItemsResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v1
+    check-cast v1, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;
+    if-eqz v1, :invalid
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+    move-result-object v2
+    instance-of v3, v2, La50/b;
+    if-eqz v3, :invalid
+    check-cast v2, La50/b;
+    iget-object v2, v2, La50/b;->b:Ljava/util/ArrayList;
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+    if-gez v3, :check_size
+    goto :invalid
+
+    :check_size
+    invoke-virtual {v2}, Ljava/util/ArrayList;->size()I
+    move-result v4
+    if-lt v3, v4, :read_item
+    goto :invalid
+
+    :read_item
+    invoke-virtual {v2, v3}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+    move-result-object v2
+
+    instance-of v3, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;
+    if-eqz v3, :captured_podcast
+    instance-of v3, v2, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;
+    if-eqz v3, :invalid
+    goto :member
+
+    :captured_podcast
+    instance-of v3, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;
+    if-eqz v3, :captured_suggestion
+    instance-of v3, v2, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;
+    if-eqz v3, :invalid
+
+    :member
+    move-object v3, v0
+    check-cast v3, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;
+    move-object v4, v2
+    check-cast v4, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;
+
+    invoke-interface {v4}, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;->getShouldHideItem()Z
+    move-result v5
+    if-nez v5, :invalid
+
+    invoke-interface {v4}, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;->getAvailability()Lcom/aspiro/wamp/model/Availability$MediaItem;
+    move-result-object v5
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+    move-result v5
+    if-eqz v5, :invalid
+
+    invoke-interface {v3}, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;->getUuid()Ljava/lang/String;
+    move-result-object v5
+    invoke-interface {v4}, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;->getUuid()Ljava/lang/String;
+    move-result-object v6
+    if-eq v5, v6, :member_identity
+    if-eqz v5, :invalid
+    invoke-virtual {v5, v6}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+    move-result v5
+    if-eqz v5, :invalid
+
+    :member_identity
+    invoke-static {v0}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object v0
+    invoke-static {v2}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object v3
+    if-eqz v0, :invalid
+    if-eqz v3, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/MediaItem;->getIndex()I
+    move-result v4
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/MediaItem;->getIndex()I
+    move-result v5
+    if-ne v4, v5, :invalid
+    goto :check_track
+
+    :captured_suggestion
+    instance-of v3, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz v3, :invalid
+    instance-of v3, v2, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz v3, :invalid
+
+    move-object v3, v2
+    check-cast v3, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    invoke-virtual {v3}, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;->getAvailability()Lcom/aspiro/wamp/model/Availability;
+    move-result-object v3
+    invoke-interface {v3}, Lcom/aspiro/wamp/model/Availability;->isAvailable()Z
+    move-result v3
+    if-eqz v3, :invalid
+
+    invoke-static {v0}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object v0
+    invoke-static {v2}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object v3
+    if-eqz v0, :invalid
+    if-eqz v3, :invalid
+
+    :check_track
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v4
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v5
+    if-ne v4, v5, :invalid
+    iget v6, p1, Lradiant/swipe/QueueRequest;->id:I
+    if-ne v5, v6, :invalid
+
+    iget-object v4, v1, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;->d:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+    if-eqz v4, :invalid
+    invoke-interface {v4, v3}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/MediaItem;)Lcom/aspiro/wamp/model/Availability$MediaItem;
+    move-result-object v4
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+    move-result v4
+    if-eqz v4, :invalid
+
+    return-object v2
+
+    :invalid
+    const/4 v0, 0x0
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;)V
+    .locals 1
+
+    if-eqz p0, :done
+    new-instance v0, Lradiant/swipe/PlaylistItemsResolver;
+    invoke-direct {v0, p0}, Lradiant/swipe/PlaylistItemsResolver;-><init>(Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;)V
+    invoke-static {p0, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+.method private playlistIndex(Lradiant/swipe/QueueRequest;)I
+    .locals 6
+
+    iget-object v0, p0, Lradiant/swipe/PlaylistItemsResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v0
+    check-cast v0, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;
+    if-eqz v0, :invalid
+
+    invoke-virtual {v0}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+    move-result-object v0
+    instance-of v1, v0, La50/b;
+    if-eqz v1, :invalid
+    check-cast v0, La50/b;
+    iget-object v0, v0, La50/b;->b:Ljava/util/ArrayList;
+
+    iget v1, p1, Lradiant/swipe/QueueRequest;->position:I
+    const/4 v2, 0x0
+    const/4 v3, 0x0
+
+    :loop
+    if-ge v2, v1, :done
+    invoke-virtual {v0, v2}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+    move-result-object v4
+    instance-of v5, v4, Lcom/aspiro/wamp/playlist/viewmodel/item/PlaylistItemViewModel;
+    if-eqz v5, :next
+    add-int/lit8 v3, v3, 0x1
+
+    :next
+    add-int/lit8 v2, v2, 0x1
+    goto :loop
+
+    :done
+    return v3
+
+    :invalid
+    const/4 v0, -0x1
+    return v0
+.end method
+
+.method private static track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    .locals 1
+
+    instance-of v0, p0, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;
+    if-eqz v0, :podcast
+    check-cast p0, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;
+    invoke-virtual {p0}, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;->getTrack()Lcom/aspiro/wamp/model/Track;
+    move-result-object p0
+    return-object p0
+
+    :podcast
+    instance-of v0, p0, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;
+    if-eqz v0, :suggestion
+    check-cast p0, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;
+    invoke-virtual {p0}, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;->getItem()Lcom/aspiro/wamp/model/MediaItemParent;
+    move-result-object p0
+    invoke-virtual {p0}, Lcom/aspiro/wamp/model/MediaItemParent;->getMediaItem()Lcom/aspiro/wamp/model/MediaItem;
+    move-result-object p0
+    instance-of v0, p0, Lcom/aspiro/wamp/model/Track;
+    if-eqz v0, :invalid
+    check-cast p0, Lcom/aspiro/wamp/model/Track;
+    return-object p0
+
+    :suggestion
+    instance-of v0, p0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz v0, :invalid
+    check-cast p0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    invoke-virtual {p0}, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;->getTrack()Lcom/aspiro/wamp/model/Track;
+    move-result-object p0
+    return-object p0
+
+    :invalid
+    const/4 p0, 0x0
+    return-object p0
+.end method
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 8
+
+    invoke-direct {p0, p1}, Lradiant/swipe/PlaylistItemsResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    move-result-object v0
+    if-eqz v0, :done
+    invoke-static {v0}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object v1
+    if-eqz v1, :done
+
+    iget-object v2, p0, Lradiant/swipe/PlaylistItemsResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v2
+    check-cast v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;
+    if-eqz v2, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+    move-result v3
+    if-eqz v3, :play
+
+    instance-of v3, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz v3, :append_member
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v3
+    invoke-static {v3}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+    move-result-object v3
+    sget v4, Lcom/aspiro/wamp/R$string;->recommended_tracks:I
+    invoke-static {v4}, Lcom/aspiro/wamp/util/h0;->c(I)Ljava/lang/String;
+    move-result-object v4
+    iget-object v5, v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;->h:Lcom/tidal/android/navigation/NavigationInfo;
+    sget-object v6, Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$None;->INSTANCE:Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$None;
+    invoke-static {v3, v4, v5, v6}, Lcom/aspiro/wamp/playqueue/source/model/b;->j(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+    move-result-object v7
+    invoke-virtual {v7, v1}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+    sget-object v6, Lcom/aspiro/wamp/playlist/ui/items/ModuleMetadata$Suggestions;->INSTANCE:Lcom/aspiro/wamp/playlist/ui/items/ModuleMetadata$Suggestions;
+    goto :append
+
+    :append_member
+    iget-object v3, v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;->c:Lcom/aspiro/wamp/playlist/ui/items/a;
+    if-eqz v3, :done
+    invoke-interface {v3}, Lcom/aspiro/wamp/playlist/ui/items/a;->k()Lcom/aspiro/wamp/playlist/viewmodel/PlaylistCollectionViewModel;
+    move-result-object v3
+    invoke-virtual {v3}, Lcom/aspiro/wamp/playlist/viewmodel/PlaylistCollectionViewModel;->getPlaylist()Lcom/aspiro/wamp/model/Playlist;
+    move-result-object v3
+    if-eqz v3, :done
+    iget-object v4, v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;->h:Lcom/tidal/android/navigation/NavigationInfo;
+    if-eqz v4, :member_nav_ready
+    invoke-static {v4}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+    move-result-object v4
+    :member_nav_ready
+    invoke-static {v3, v4}, Lcom/aspiro/wamp/playqueue/source/model/b;->f(Lcom/aspiro/wamp/model/Playlist;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/PlaylistSource;
+    move-result-object v7
+    invoke-virtual {v7, v1}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+    sget-object v6, Lcom/aspiro/wamp/playlist/ui/items/ModuleMetadata$Items;->INSTANCE:Lcom/aspiro/wamp/playlist/ui/items/ModuleMetadata$Items;
+
+    :append
+    invoke-virtual {v2}, Landroid/view/View;->getContext()Landroid/content/Context;
+    move-result-object v3
+    invoke-static {v3, v1, v6, v7}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    goto :done
+
+    :play
+    iget-object v3, v2, Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;->c:Lcom/aspiro/wamp/playlist/ui/items/a;
+    if-eqz v3, :done
+    instance-of v0, v0, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz v0, :play_member
+    invoke-interface {v3, v1}, Lcom/aspiro/wamp/playlist/ui/items/a;->c(Lcom/aspiro/wamp/model/Track;)V
+    goto :done
+
+    :play_member
+    invoke-direct {p0, p1}, Lradiant/swipe/PlaylistItemsResolver;->playlistIndex(Lradiant/swipe/QueueRequest;)I
+    move-result v0
+    if-gez v0, :start_member
+    goto :done
+    :start_member
+    invoke-interface {v3, v0}, Lcom/aspiro/wamp/playlist/ui/items/a;->i(I)V
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    iget-object v0, p0, Lradiant/swipe/PlaylistItemsResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v0
+    if-ne v0, p1, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+    move-result v0
+    const/4 v1, -0x1
+    if-ne v0, v1, :has_position
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+    move-result-object p1
+    instance-of v1, p1, La50/b;
+    if-eqz v1, :invalid
+    check-cast p1, La50/b;
+    iget-object p1, p1, La50/b;->b:Ljava/util/ArrayList;
+    invoke-virtual {p1}, Ljava/util/ArrayList;->size()I
+    move-result v1
+    if-lt v0, v1, :read_item
+    goto :invalid
+
+    :read_item
+    invoke-virtual {p1, v0}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+    move-result-object p1
+
+    instance-of v1, p2, Lij/q$a;
+    if-eqz v1, :podcast_holder
+    instance-of v1, p1, Lcom/aspiro/wamp/playlist/viewmodel/item/TrackViewModel;
+    if-eqz v1, :invalid
+    goto :create
+
+    :podcast_holder
+    instance-of v1, p2, Lij/a0$a;
+    if-eqz v1, :suggestion_holder
+    instance-of v1, p1, Lcom/aspiro/wamp/playlist/viewmodel/item/PodcastTrackViewModel;
+    if-eqz v1, :invalid
+    goto :create
+
+    :suggestion_holder
+    instance-of p2, p2, Lij/j0$a;
+    if-eqz p2, :invalid
+    instance-of p2, p1, Lcom/aspiro/wamp/playlist/viewmodel/item/SuggestedTrackViewModel;
+    if-eqz p2, :invalid
+
+    :create
+    invoke-static {p1}, Lradiant/swipe/PlaylistItemsResolver;->track(Ljava/lang/Object;)Lcom/aspiro/wamp/model/Track;
+    move-result-object p2
+    if-eqz p2, :invalid
+    invoke-virtual {p2}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v1
+    new-instance v2, Lradiant/swipe/QueueRequest;
+    invoke-direct {v2, v0, p1, v1}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+    invoke-direct {p0, v2}, Lradiant/swipe/PlaylistItemsResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    move-result-object p1
+    if-eqz p1, :invalid
+    return-object v2
+
+    :invalid
+    const/4 p1, 0x0
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/PublicPlaylistQueueAction.smali
+++ b/patches/extension/radiant/swipe/PublicPlaylistQueueAction.smali
@@ -1,0 +1,111 @@
+.class public final Lradiant/swipe/PublicPlaylistQueueAction;
+.super Ljava/lang/Object;
+.source "PublicPlaylistQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final itemId:Ljava/lang/String;
+
+.field private final moduleUuid:Ljava/lang/String;
+
+.field private final pageId:Ljava/lang/String;
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$d;)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->callback:Lam0/l;
+
+    iput-object p2, p0, Lradiant/swipe/PublicPlaylistQueueAction;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/PublicPlaylistQueueAction;->moduleUuid:Ljava/lang/String;
+
+    iget-object p1, p4, Lm40/e$d;->a:Ljava/lang/String;
+
+    iput-object p1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->itemId:Ljava/lang/String;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 6
+
+    iget-object v0, p0, Lradiant/swipe/PublicPlaylistQueueAction;->callback:Lam0/l;
+
+    if-eqz v0, :done
+
+    iget-object v1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    iget-object v4, p0, Lradiant/swipe/PublicPlaylistQueueAction;->itemId:Ljava/lang/String;
+
+    if-eqz v4, :done
+
+    new-instance v0, Lradiant/swipe/DynamicMediaQueueEvent;
+
+    iget-object v2, p0, Lradiant/swipe/PublicPlaylistQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/PublicPlaylistQueueAction;->moduleUuid:Ljava/lang/String;
+
+    const/4 v5, 0x3
+
+    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+
+    iget-object v1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->callback:Lam0/l;
+
+    invoke-interface {v1, v0}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method
+
+.method public stableKey()Ljava/lang/String;
+    .locals 3
+
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    const-string v1, "ppl:"
+
+    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    iget-object v1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    const/16 v1, 0x3a
+
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    iget-object v1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->itemId:Ljava/lang/String;
+
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/PublicPlaylistQueueAction.smali
+++ b/patches/extension/radiant/swipe/PublicPlaylistQueueAction.smali
@@ -39,8 +39,8 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
-    .locals 6
+.method public invoke(I)Ljava/lang/Object;
+    .locals 7
 
     iget-object v0, p0, Lradiant/swipe/PublicPlaylistQueueAction;->callback:Lam0/l;
 
@@ -62,7 +62,9 @@
 
     const/4 v5, 0x3
 
-    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+    move v6, p1
+
+    invoke-direct/range {v0 .. v6}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
 
     iget-object v1, p0, Lradiant/swipe/PublicPlaylistQueueAction;->callback:Lam0/l;
 
@@ -70,6 +72,18 @@
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/PublicPlaylistQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -117,6 +117,94 @@
     return v0
 .end method
 
+.method public static mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    .locals 4
+
+    const/4 v0, 0x0
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    :unwrap_context
+    instance-of v1, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v1, :has_activity
+
+    instance-of v1, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v1, :done
+
+    move-object v1, p0
+
+    check-cast v1, Landroid/content/ContextWrapper;
+
+    invoke-virtual {v1}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v1
+
+    if-eq v1, p0, :done
+
+    move-object p0, v1
+
+    goto :unwrap_context
+
+    :has_activity
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    if-eqz p4, :done
+
+    iget-object v1, p4, Lh4/a;->h:Lu3/a$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lu3/a$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lu3/a;
+
+    move-result-object v1
+
+    iget-object v1, v1, Lu3/a;->e:Lj3/n$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lj3/n$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lj3/n;
+
+    move-result-object p1
+
+    check-cast p0, Landroidx/fragment/app/FragmentActivity;
+
+    invoke-virtual {p1, p0}, Lj3/n;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object p0
+
+    invoke-virtual {p0}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object p0
+
+    check-cast p0, Le5/z$n2;
+
+    invoke-virtual {p0}, Le5/z$n2;->x3()Lcom/aspiro/wamp/playback/e0;
+
+    move-result-object p0
+
+    invoke-virtual {p1}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+
+    move-result-object p1
+
+    const/4 p2, 0x1
+
+    invoke-virtual {p0, p1, p3, p2, v0}, Lcom/aspiro/wamp/playback/e0;->a(Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;ZLjava/lang/String;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v0
+
+    :done
+    return-object v0
+.end method
+
 .method public static playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
     .locals 4
 

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -39,6 +39,132 @@
     return-object p0
 .end method
 
+.method public static addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+    .locals 2
+
+    if-eqz p1, :done
+
+    if-eqz p2, :done
+
+    if-eqz p4, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    iget-object v0, p4, Lh4/a;->b:Lo3/a$a;
+
+    if-eqz v0, :done
+
+    invoke-interface {v0, p1, p2, p3}, Lo3/a$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lo3/a;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    iget-object v0, v0, Lo3/a;->l:Lcom/aspiro/wamp/module/album/AlbumProvider;
+
+    if-eqz v0, :done
+
+    new-instance v1, Lc3/h;
+
+    invoke-direct {v1, p1, v0, p2, p3}, Lc3/h;-><init>(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/module/album/AlbumProvider;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    invoke-virtual {v1, p0}, Lc3/h;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    :done
+    return-void
+.end method
+
+.method public static addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+    .locals 1
+
+    if-eqz p1, :done
+
+    if-eqz p2, :done
+
+    if-eqz p4, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    iget-object v0, p4, Lh4/a;->h:Lu3/a$a;
+
+    if-eqz v0, :done
+
+    invoke-interface {v0, p1, p2, p3}, Lu3/a$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lu3/a;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    iget-object v0, v0, Lu3/a;->j:Lj3/k$a;
+
+    if-eqz v0, :done
+
+    invoke-interface {v0, p1, p2, p3}, Lj3/k$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lj3/k;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    invoke-virtual {v0, p0}, Lj3/k;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    :done
+    return-void
+.end method
+
+.method public static addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    .locals 1
+
+    if-eqz p1, :done
+
+    if-eqz p2, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    new-instance v0, Lcom/aspiro/wamp/contextmenu/item/playlist/f;
+
+    invoke-direct {v0, p1, p2, p3}, Lcom/aspiro/wamp/contextmenu/item/playlist/f;-><init>(Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    invoke-virtual {v0, p0}, Lcom/aspiro/wamp/contextmenu/item/playlist/f;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    :done
+    return-void
+.end method
+
+.method public static addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
+    .locals 1
+
+    if-eqz p1, :done
+
+    if-eqz p2, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    new-instance v0, Lm3/d;
+
+    invoke-direct {v0, p1, p2, p3}, Lm3/d;-><init>(Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
+
+    invoke-virtual {v0, p0}, Lm3/d;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    :done
+    return-void
+.end method
+
 .method public static album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
     .locals 8
 

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -117,6 +117,88 @@
     return v0
 .end method
 
+.method public static playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    .locals 4
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    invoke-virtual {p1}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v0
+
+    if-lez v0, :done
+
+    :unwrap_context
+    instance-of v0, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v0, :has_activity
+
+    instance-of v0, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v0, :done
+
+    move-object v0, p0
+
+    check-cast v0, Landroid/content/ContextWrapper;
+
+    invoke-virtual {v0}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    if-eq v0, p0, :done
+
+    move-object p0, v0
+
+    goto :unwrap_context
+
+    :has_activity
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v0
+
+    check-cast v0, Le5/z$n2;
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    iget-object v1, v0, Le5/z$n2;->w8:Ldagger/internal/f;
+
+    invoke-interface {v1}, Lql0/a;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/aspiro/wamp/contextmenu/item/playlist/h$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lcom/aspiro/wamp/contextmenu/item/playlist/h$a;->a(Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/contextmenu/item/playlist/h;
+
+    move-result-object p2
+
+    check-cast p0, Landroidx/fragment/app/FragmentActivity;
+
+    invoke-virtual {p2, p0}, Lcom/aspiro/wamp/contextmenu/item/playlist/h;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-virtual {v0}, Le5/z$n2;->y3()Lcom/aspiro/wamp/playback/k0;
+
+    move-result-object p0
+
+    invoke-virtual {p0, p1, p3}, Lcom/aspiro/wamp/playback/k0;->c(Lcom/aspiro/wamp/model/Playlist;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    :done
+    return-void
+.end method
+
 .method public static track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
     .locals 2
 

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -1,0 +1,180 @@
+.class public final Lradiant/swipe/QueueExecutor;
+.super Ljava/lang/Object;
+.source "QueueExecutor.smali"
+
+
+# direct methods
+.method public static album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    .locals 8
+
+    const/4 v0, 0x0
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v1
+
+    check-cast v1, Le5/z$n2;
+
+    invoke-virtual {v1}, Le5/z$n2;->r2()Lcom/aspiro/wamp/playqueue/g1;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/playqueue/g1;->a()Lcom/aspiro/wamp/player/d;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/player/d;->b()Lcom/aspiro/wamp/model/MediaItemParent;
+
+    move-result-object v2
+
+    if-eqz v2, :play
+
+    if-eqz p4, :done
+
+    iget-object v2, p4, Lh4/a;->b:Lo3/a$a;
+
+    invoke-interface {v2, p1, p2, p3}, Lo3/a$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lo3/a;
+
+    move-result-object v2
+
+    iget-object v2, v2, Lo3/a;->e:Lc3/i$a;
+
+    invoke-interface {v2, p1, p2, p3}, Lc3/i$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lc3/i;
+
+    move-result-object p1
+
+    instance-of p2, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-eqz p2, :done
+
+    check-cast p0, Landroidx/fragment/app/FragmentActivity;
+
+    invoke-virtual {p1, p0}, Lc3/i;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-virtual {v1}, Le5/z$n2;->u3()Lcom/aspiro/wamp/playback/f;
+
+    move-result-object p0
+
+    invoke-virtual {p1}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result p1
+
+    const/4 p2, 0x1
+
+    invoke-virtual {p0, p1, p3, p2, v0}, Lcom/aspiro/wamp/playback/f;->a(ILcom/tidal/android/navigation/NavigationInfo;ZLjava/lang/String;)Lhu/akarnokd/rxjava/interop/f;
+
+    move-result-object v0
+
+    :done
+    return-object v0
+.end method
+
+.method public static hasActiveQueue()Z
+    .locals 2
+
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v0
+
+    check-cast v0, Le5/z$n2;
+
+    invoke-virtual {v0}, Le5/z$n2;->r2()Lcom/aspiro/wamp/playqueue/g1;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/playqueue/g1;->a()Lcom/aspiro/wamp/player/d;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/player/d;->b()Lcom/aspiro/wamp/model/MediaItemParent;
+
+    move-result-object v0
+
+    if-eqz v0, :empty
+
+    const/4 v0, 0x1
+
+    return v0
+
+    :empty
+    const/4 v0, 0x0
+
+    return v0
+.end method
+
+.method public static track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    .locals 2
+
+    const/4 v0, 0x0
+
+    :unwrap_context
+    instance-of v1, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v1, :has_activity
+
+    instance-of v1, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v1, :done
+
+    move-object v1, p0
+
+    check-cast v1, Landroid/content/ContextWrapper;
+
+    invoke-virtual {v1}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v1
+
+    if-eq v1, p0, :done
+
+    move-object p0, v1
+
+    goto :unwrap_context
+
+    :has_activity
+
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v1
+
+    check-cast v1, Le5/z$n2;
+
+    iget-object v1, v1, Le5/z$n2;->k9:Ldagger/internal/f;
+
+    invoke-interface {v1}, Lql0/a;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lm3/f$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lm3/f$a;->a(Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Lm3/f;
+
+    move-result-object p1
+
+    check-cast p0, Landroidx/fragment/app/FragmentActivity;
+
+    invoke-virtual {p1, p0}, Lm3/f;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    const/4 v0, 0x1
+
+    :done
+    return v0
+.end method

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -4,6 +4,41 @@
 
 
 # direct methods
+.method private static activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+    .locals 1
+
+    :unwrap
+    instance-of v0, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v0, :ready
+
+    instance-of v0, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v0, :invalid
+
+    check-cast p0, Landroid/content/ContextWrapper;
+
+    invoke-virtual {p0}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    if-eq v0, p0, :invalid
+
+    move-object p0, v0
+
+    goto :unwrap
+
+    :ready
+    check-cast p0, Landroidx/fragment/app/FragmentActivity;
+
+    return-object p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return-object p0
+.end method
+
 .method public static album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
     .locals 8
 
@@ -302,6 +337,210 @@
 
     :done
     return-void
+.end method
+
+.method public static playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    .locals 3
+
+    const/4 v0, 0x0
+
+    if-eqz p1, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    if-eqz p4, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    iget-object v1, p4, Lh4/a;->b:Lo3/a$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lo3/a$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lo3/a;
+
+    move-result-object v1
+
+    iget-object v1, v1, Lo3/a;->d:Lc3/l$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lc3/l$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lc3/l;
+
+    move-result-object p1
+
+    invoke-virtual {p1, p0}, Lc3/l;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-static {p0, p1, p2, p3, p4}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v0
+
+    :done
+    return-object v0
+.end method
+
+.method public static playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    .locals 2
+
+    const/4 v0, 0x0
+
+    if-eqz p1, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    if-eqz p4, :done
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    iget-object v1, p4, Lh4/a;->h:Lu3/a$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lu3/a$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lu3/a;
+
+    move-result-object v1
+
+    iget-object v1, v1, Lu3/a;->d:Lj3/q$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lj3/q$a;->a(Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lj3/q;
+
+    move-result-object p1
+
+    invoke-virtual {p1, p0}, Lj3/q;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-static {p0, p1, p2, p3, p4}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object v0
+
+    :done
+    return-object v0
+.end method
+
+.method public static playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    .locals 2
+
+    if-eqz p1, :done
+
+    invoke-virtual {p1}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v0
+
+    if-lez v0, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v0
+
+    if-eqz v0, :play
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v0
+
+    check-cast v0, Le5/z$n2;
+
+    iget-object v0, v0, Le5/z$n2;->v8:Ldagger/internal/f;
+
+    invoke-interface {v0}, Lql0/a;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/contextmenu/item/playlist/u$a;
+
+    invoke-interface {v0, p1, p2, p3}, Lcom/aspiro/wamp/contextmenu/item/playlist/u$a;->a(Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/contextmenu/item/playlist/u;
+
+    move-result-object p1
+
+    invoke-virtual {p1, p0}, Lcom/aspiro/wamp/contextmenu/item/playlist/u;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    goto :done
+
+    :play
+    invoke-static {p0, p1, p2, p3}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    :done
+    return-void
+.end method
+
+.method public static playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    .locals 2
+
+    const/4 v0, 0x0
+
+    if-eqz p1, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    invoke-static {p0}, Lradiant/swipe/QueueExecutor;->activity(Landroid/content/Context;)Landroidx/fragment/app/FragmentActivity;
+
+    move-result-object p0
+
+    if-eqz p0, :done
+
+    invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/App;->e()Le5/c;
+
+    move-result-object v1
+
+    check-cast v1, Le5/z$n2;
+
+    iget-object v1, v1, Le5/z$n2;->K9:Ldagger/internal/f;
+
+    invoke-interface {v1}, Lql0/a;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lm3/i$a;
+
+    invoke-interface {v1, p1, p2, p3}, Lm3/i$a;->a(Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Lm3/i;
+
+    move-result-object p1
+
+    invoke-virtual {p1, p0}, Lm3/i;->b(Landroidx/fragment/app/FragmentActivity;)V
+
+    const/4 v0, 0x1
+
+    goto :done
+
+    :play
+    invoke-static {p0, p1, p2, p3}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    move-result v0
+
+    :done
+    return v0
 .end method
 
 .method public static track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z

--- a/patches/extension/radiant/swipe/QueueExecutor.smali
+++ b/patches/extension/radiant/swipe/QueueExecutor.smali
@@ -9,8 +9,6 @@
 
     const/4 v0, 0x0
 
-    if-eqz p0, :done
-
     if-eqz p1, :done
 
     invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
@@ -39,6 +37,31 @@
 
     if-eqz p4, :done
 
+    :unwrap_context
+    instance-of v2, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v2, :has_activity
+
+    instance-of v2, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v2, :done
+
+    move-object v2, p0
+
+    check-cast v2, Landroid/content/ContextWrapper;
+
+    invoke-virtual {v2}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v2
+
+    if-eq v2, p0, :done
+
+    move-object p0, v2
+
+    goto :unwrap_context
+
+    :has_activity
+
     iget-object v2, p4, Lh4/a;->b:Lo3/a$a;
 
     invoke-interface {v2, p1, p2, p3}, Lo3/a$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lo3/a;
@@ -50,10 +73,6 @@
     invoke-interface {v2, p1, p2, p3}, Lc3/i$a;->a(Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)Lc3/i;
 
     move-result-object p1
-
-    instance-of p2, p0, Landroidx/fragment/app/FragmentActivity;
-
-    if-eqz p2, :done
 
     check-cast p0, Landroidx/fragment/app/FragmentActivity;
 
@@ -122,9 +141,15 @@
 
     const/4 v0, 0x0
 
-    if-eqz p0, :done
-
     if-eqz p1, :done
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-eqz v1, :play
+
+    if-eqz p4, :done
 
     :unwrap_context
     instance-of v1, p0, Landroidx/fragment/app/FragmentActivity;
@@ -150,13 +175,6 @@
     goto :unwrap_context
 
     :has_activity
-    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
-
-    move-result v1
-
-    if-eqz v1, :play
-
-    if-eqz p4, :done
 
     iget-object v1, p4, Lh4/a;->h:Lu3/a$a;
 
@@ -208,8 +226,6 @@
 .method public static playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
     .locals 4
 
-    if-eqz p0, :done
-
     if-eqz p1, :done
 
     invoke-virtual {p1}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
@@ -218,30 +234,6 @@
 
     if-lez v0, :done
 
-    :unwrap_context
-    instance-of v0, p0, Landroidx/fragment/app/FragmentActivity;
-
-    if-nez v0, :has_activity
-
-    instance-of v0, p0, Landroid/content/ContextWrapper;
-
-    if-eqz v0, :done
-
-    move-object v0, p0
-
-    check-cast v0, Landroid/content/ContextWrapper;
-
-    invoke-virtual {v0}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
-
-    move-result-object v0
-
-    if-eq v0, p0, :done
-
-    move-object p0, v0
-
-    goto :unwrap_context
-
-    :has_activity
     invoke-static {}, Lcom/aspiro/wamp/App$a;->a()Lcom/aspiro/wamp/App;
 
     move-result-object v0
@@ -257,6 +249,31 @@
     move-result v1
 
     if-eqz v1, :play
+
+    :unwrap_context
+    instance-of v1, p0, Landroidx/fragment/app/FragmentActivity;
+
+    if-nez v1, :has_activity
+
+    instance-of v1, p0, Landroid/content/ContextWrapper;
+
+    if-eqz v1, :done
+
+    move-object v1, p0
+
+    check-cast v1, Landroid/content/ContextWrapper;
+
+    invoke-virtual {v1}, Landroid/content/ContextWrapper;->getBaseContext()Landroid/content/Context;
+
+    move-result-object v1
+
+    if-eq v1, p0, :done
+
+    move-object p0, v1
+
+    goto :unwrap_context
+
+    :has_activity
 
     iget-object v1, v0, Le5/z$n2;->w8:Ldagger/internal/f;
 

--- a/patches/extension/radiant/swipe/QueueRequest.smali
+++ b/patches/extension/radiant/swipe/QueueRequest.smali
@@ -2,8 +2,17 @@
 .super Ljava/lang/Object;
 .source "QueueRequest.smali"
 
+# static fields
+.field public static final ACTION_NONE:I = 0x0
+
+.field public static final ACTION_PLAY_NEXT:I = 0x1
+
+.field public static final ACTION_ADD_TO_QUEUE:I = 0x2
+
 
 # instance fields
+.field public action:I
+
 .field public final id:I
 
 .field public final media:Ljava/lang/Object;

--- a/patches/extension/radiant/swipe/QueueRequest.smali
+++ b/patches/extension/radiant/swipe/QueueRequest.smali
@@ -1,0 +1,27 @@
+.class public final Lradiant/swipe/QueueRequest;
+.super Ljava/lang/Object;
+.source "QueueRequest.smali"
+
+
+# instance fields
+.field public final id:I
+
+.field public final media:Ljava/lang/Object;
+
+.field public final position:I
+
+
+# direct methods
+.method public constructor <init>(ILjava/lang/Object;I)V
+    .locals 0
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput p1, p0, Lradiant/swipe/QueueRequest;->position:I
+
+    iput-object p2, p0, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    iput p3, p0, Lradiant/swipe/QueueRequest;->id:I
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/QueueRequest.smali
+++ b/patches/extension/radiant/swipe/QueueRequest.smali
@@ -9,6 +9,8 @@
 
 .field public static final ACTION_ADD_TO_QUEUE:I = 0x2
 
+.field public static final ACTION_ADD_TO_PLAYLIST:I = 0x3
+
 
 # instance fields
 .field public action:I

--- a/patches/extension/radiant/swipe/QueueRowResolver.smali
+++ b/patches/extension/radiant/swipe/QueueRowResolver.smali
@@ -1,0 +1,14 @@
+.class public interface abstract Lradiant/swipe/QueueRowResolver;
+.super Ljava/lang/Object;
+.source "QueueRowResolver.smali"
+
+
+# virtual methods
+.method public abstract execute(Lradiant/swipe/QueueRequest;)V
+.end method
+
+.method public abstract isValid(Lradiant/swipe/QueueRequest;)Z
+.end method
+
+.method public abstract resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+.end method

--- a/patches/extension/radiant/swipe/QueueRowResolver.smali
+++ b/patches/extension/radiant/swipe/QueueRowResolver.smali
@@ -7,8 +7,5 @@
 .method public abstract execute(Lradiant/swipe/QueueRequest;)V
 .end method
 
-.method public abstract isValid(Lradiant/swipe/QueueRequest;)Z
-.end method
-
 .method public abstract resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
 .end method

--- a/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
@@ -122,6 +122,8 @@
 .method public execute(Lradiant/swipe/QueueRequest;)V
     .locals 7
 
+    iget v6, p1, Lradiant/swipe/QueueRequest;->action:I
+
     invoke-direct {p0, p1}, Lradiant/swipe/SearchAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
 
     move-result-object p1
@@ -158,12 +160,24 @@
 
     iget-object v5, v1, Lld/c;->d:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
 
-    iget-object v6, v1, Lld/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+    iget-object p0, v1, Lld/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
-    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    const/4 v1, 0x1
+
+    if-ne v6, v1, :append
+
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
 
+    goto :retain
+
+    :append
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    :retain
     if-eqz p1, :done
 
     iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;->g:Lio/reactivex/disposables/CompositeDisposable;

--- a/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
@@ -162,6 +162,10 @@
 
     iget-object p0, v1, Lld/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
+    const/4 v1, 0x3
+
+    if-eq v6, v1, :add_to_playlist
+
     const/4 v1, 0x1
 
     if-ne v6, v1, :append
@@ -176,6 +180,13 @@
     invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
 
     move-result-object p1
+
+    goto :retain
+
+    :add_to_playlist
+    invoke-static {v3, v4, v5, p0, v2}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+
+    goto :done
 
     :retain
     if-eqz p1, :done

--- a/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchAlbumsResolver.smali
@@ -1,0 +1,248 @@
+.class public final Lradiant/swipe/SearchAlbumsResolver;
+.super Ljava/lang/Object;
+.source "SearchAlbumsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/SearchAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lzc/a;
+    .locals 5
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p0, Lradiant/swipe/SearchAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;
+
+    if-eqz v0, :invalid
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;->f:Lid/e;
+
+    if-eqz v1, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;->N()La50/d;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v0
+
+    iget v1, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v1, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v0}, Ljava/util/List;->size()I
+
+    move-result v2
+
+    if-lt v1, v2, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {v0, v1}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v0
+
+    instance-of v1, v0, Lzc/a;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lzc/a;
+
+    iget-boolean v1, v0, Lzc/a;->k:Z
+
+    if-eqz v1, :invalid
+
+    iget-object v1, v0, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v1, v2, :invalid
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/SearchAlbumsResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/SearchAlbumsResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 7
+
+    invoke-direct {p0, p1}, Lradiant/swipe/SearchAlbumsResolver;->current(Lradiant/swipe/QueueRequest;)Lzc/a;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, p0, Lradiant/swipe/SearchAlbumsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;
+
+    if-eqz v0, :done
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;->c:Lld/c;
+
+    if-eqz v1, :done
+
+    iget-object v2, v1, Lld/c;->a:Lx40/a;
+
+    instance-of v3, v2, Lh4/a;
+
+    if-eqz v3, :done
+
+    check-cast v2, Lh4/a;
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v3
+
+    iget-object v4, p1, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    iget-object v5, v1, Lld/c;->d:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    iget-object v6, v1, Lld/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v3, v4, v5, v6, v2}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;->g:Lio/reactivex/disposables/CompositeDisposable;
+
+    invoke-virtual {v0, p1}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of v0, p2, Ljd/d$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/d;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/d;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lzc/a;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lzc/a;
+
+    iget-boolean v0, p1, Lzc/a;->k:Z
+
+    if-eqz v0, :invalid
+
+    iget-object v0, p1, Lzc/a;->b:Lcom/aspiro/wamp/model/Album;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Album;->getId()I
+
+    move-result v1
+
+    new-instance v2, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v2, p2, v0, v1}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v2
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
@@ -155,7 +155,9 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 6
+    .locals 7
+
+    iget v6, p1, Lradiant/swipe/QueueRequest;->action:I
 
     invoke-direct {p0, p1}, Lradiant/swipe/SearchPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
 
@@ -189,9 +191,18 @@
 
     invoke-direct {v4, v5}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;)V
 
-    iget-object v5, v1, Lzf/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+    iget-object p0, v1, Lzf/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
-    invoke-static {v2, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    const/4 v0, 0x1
+
+    if-ne v6, v0, :append
+
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
@@ -193,6 +193,10 @@
 
     iget-object p0, v1, Lzf/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
 
+    const/4 v0, 0x3
+
+    if-eq v6, v0, :add_to_playlist
+
     const/4 v0, 0x1
 
     if-ne v6, v0, :append
@@ -203,6 +207,11 @@
 
     :append
     invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :add_to_playlist
+    invoke-static {v2, v3, v4, p0}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
+++ b/patches/extension/radiant/swipe/SearchPlaylistsResolver.smali
@@ -1,0 +1,296 @@
+.class public final Lradiant/swipe/SearchPlaylistsResolver;
+.super Ljava/lang/Object;
+.source "SearchPlaylistsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/SearchPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lcf/b;
+    .locals 6
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lcom/aspiro/wamp/model/Playlist;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/model/Playlist;
+
+    iget-object v1, p0, Lradiant/swipe/SearchPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;
+
+    if-eqz v1, :invalid
+
+    iget-object v2, v1, Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;->g:Lwf/d;
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;->N()La50/d;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v2, :check_size
+
+    goto :invalid
+
+    :check_size
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    move-result v3
+
+    if-lt v2, v3, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {v1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v2, v1, Lcf/b;
+
+    if-eqz v2, :invalid
+
+    check-cast v1, Lcf/b;
+
+    iget-boolean v2, v1, Lcf/b;->h:Z
+
+    if-eqz v2, :invalid
+
+    iget-boolean v2, v1, Lcf/b;->f:Z
+
+    if-eqz v2, :check_playlist
+
+    const-string v2, "NOT_READY"
+
+    iget-object v3, v1, Lcf/b;->g:Ljava/lang/String;
+
+    invoke-virtual {v2, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v2
+
+    if-nez v2, :invalid
+
+    :check_playlist
+    iget-object v2, v1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v3
+
+    if-lez v3, :invalid
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-virtual {v2, v0}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v0
+
+    if-eqz v0, :invalid
+
+    return-object v1
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/SearchPlaylistsResolver;
+
+    invoke-direct {v0, p0}, Lradiant/swipe/SearchPlaylistsResolver;-><init>(Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 6
+
+    invoke-direct {p0, p1}, Lradiant/swipe/SearchPlaylistsResolver;->current(Lradiant/swipe/QueueRequest;)Lcf/b;
+
+    move-result-object p1
+
+    if-eqz p1, :done
+
+    iget-object v0, p0, Lradiant/swipe/SearchPlaylistsResolver;->fragment:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;
+
+    if-eqz v0, :done
+
+    iget-object v1, v0, Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;->c:Lzf/c;
+
+    if-eqz v1, :done
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v2
+
+    iget-object v3, p1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    new-instance v4, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    const-string v5, "mycollection_search_playlists"
+
+    invoke-direct {v4, v5}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;)V
+
+    iget-object v5, v1, Lzf/c;->c:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v2, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    instance-of v0, p2, Lxf/d$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    const/4 v0, -0x1
+
+    if-ne p2, v0, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/d;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/d;
+
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+
+    move-result-object p1
+
+    invoke-interface {p1}, Ljava/util/List;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-interface {p1, p2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lcf/b;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lcf/b;
+
+    iget-boolean v0, p1, Lcf/b;->h:Z
+
+    if-eqz v0, :invalid
+
+    iget-boolean v0, p1, Lcf/b;->f:Z
+
+    if-eqz v0, :check_playlist
+
+    const-string v0, "NOT_READY"
+
+    iget-object v1, p1, Lcf/b;->g:Ljava/lang/String;
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result v0
+
+    if-nez v0, :invalid
+
+    :check_playlist
+    iget-object v0, p1, Lcf/b;->a:Lcom/aspiro/wamp/model/Playlist;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+
+    move-result v1
+
+    if-lez v1, :invalid
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Ljava/lang/String;->hashCode()I
+
+    move-result v2
+
+    new-instance v3, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v3, p2, v0, v2}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    return-object v3
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/SuggestionsResolver.smali
+++ b/patches/extension/radiant/swipe/SuggestionsResolver.smali
@@ -1,0 +1,431 @@
+.class public final Lradiant/swipe/SuggestionsResolver;
+.super Ljava/lang/Object;
+.source "SuggestionsResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+
+# instance fields
+.field private final host:Ljava/lang/ref/WeakReference;
+
+.field private final recycler:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method private constructor <init>(Landroidx/fragment/app/Fragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p2}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    iput-object v0, p0, Lradiant/swipe/SuggestionsResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+    .locals 8
+
+    if-eqz p1, :invalid
+
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    instance-of v1, v0, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    iget-object v1, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v2, v1, Landroidx/fragment/app/Fragment;
+
+    if-eqz v2, :invalid
+
+    check-cast v1, Landroidx/fragment/app/Fragment;
+
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getView()Landroid/view/View;
+
+    move-result-object v2
+
+    if-eqz v2, :invalid
+
+    iget-object v2, p0, Lradiant/swipe/SuggestionsResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v2
+
+    check-cast v2, Landroidx/recyclerview/widget/RecyclerView;
+
+    if-eqz v2, :invalid
+
+    invoke-virtual {v2}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object v2
+
+    instance-of v3, v2, La50/b;
+
+    if-eqz v3, :invalid
+
+    check-cast v2, La50/b;
+
+    iget-object v2, v2, La50/b;->b:Ljava/util/ArrayList;
+
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    if-gez v3, :adapter_bounds
+
+    goto :invalid
+
+    :adapter_bounds
+    invoke-virtual {v2}, Ljava/util/ArrayList;->size()I
+
+    move-result v4
+
+    if-lt v3, v4, :adapter_item
+
+    goto :invalid
+
+    :adapter_item
+    invoke-virtual {v2, v3}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+
+    move-result-object v2
+
+    instance-of v4, v2, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    if-eqz v4, :invalid
+
+    check-cast v2, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getMediaItem()Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v4
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getMediaItem()Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v5
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v4
+
+    invoke-virtual {v5}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v6
+
+    if-ne v4, v6, :invalid
+
+    iget v7, p1, Lradiant/swipe/QueueRequest;->id:I
+
+    if-ne v6, v7, :invalid
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getAvailability()Lcom/aspiro/wamp/model/Availability;
+
+    move-result-object v4
+
+    invoke-interface {v4}, Lcom/aspiro/wamp/model/Availability;->isAvailable()Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    invoke-direct {p0}, Lradiant/swipe/SuggestionsResolver;->availability()Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    move-result-object v4
+
+    if-eqz v4, :invalid
+
+    invoke-interface {v4, v5}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/MediaItem;)Lcom/aspiro/wamp/model/Availability$MediaItem;
+
+    move-result-object v4
+
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+
+    move-result v4
+
+    if-eqz v4, :invalid
+
+    invoke-direct {p0}, Lradiant/swipe/SuggestionsResolver;->viewModel()Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+
+    move-result-object v1
+
+    instance-of v4, v1, Lcom/aspiro/wamp/nowplaying/view/suggestions/a1;
+
+    if-eqz v4, :invalid
+
+    check-cast v1, Lcom/aspiro/wamp/nowplaying/view/suggestions/a1;
+
+    iget-object v1, v1, Lcom/aspiro/wamp/nowplaying/view/suggestions/a1;->o:Ljava/lang/Object;
+
+    instance-of v4, v1, Ljava/util/List;
+
+    if-eqz v4, :invalid
+
+    check-cast v1, Ljava/util/List;
+
+    invoke-interface {v1}, Ljava/util/List;->size()I
+
+    move-result v4
+
+    if-lt v3, v4, :viewmodel_item
+
+    goto :invalid
+
+    :viewmodel_item
+    invoke-interface {v1, v3}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v3, v1, Lcom/aspiro/wamp/model/Track;
+
+    if-eqz v3, :invalid
+
+    check-cast v1, Lcom/aspiro/wamp/model/Track;
+
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v1
+
+    if-ne v6, v1, :invalid
+
+    return-object v2
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method private availability()Lcom/aspiro/wamp/model/AvailabilityInteractor;
+    .locals 2
+
+    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    instance-of v1, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;
+
+    if-eqz v1, :dialog
+
+    check-cast v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;
+
+    iget-object v0, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;->d:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    return-object v0
+
+    :dialog
+    instance-of v1, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;
+
+    iget-object v0, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;->d:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+.method public static install(Landroidx/fragment/app/Fragment;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    new-instance v0, Lradiant/swipe/SuggestionsResolver;
+
+    invoke-direct {v0, p0, p1}, Lradiant/swipe/SuggestionsResolver;-><init>(Landroidx/fragment/app/Fragment;Landroidx/recyclerview/widget/RecyclerView;)V
+
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+
+    :done
+    return-void
+.end method
+
+.method private viewModel()Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+    .locals 2
+
+    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    instance-of v1, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;
+
+    if-eqz v1, :dialog
+
+    check-cast v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;
+
+    iget-object v0, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/h;->c:Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+
+    return-object v0
+
+    :dialog
+    instance-of v1, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;
+
+    if-eqz v1, :invalid
+
+    check-cast v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;
+
+    iget-object v0, v0, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;->c:Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method
+
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 4
+
+    invoke-direct {p0, p1}, Lradiant/swipe/SuggestionsResolver;->current(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    move-result-object v0
+
+    if-eqz v0, :done
+
+    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    invoke-direct {p0}, Lradiant/swipe/SuggestionsResolver;->viewModel()Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+
+    move-result-object v1
+
+    if-eqz v1, :done
+
+    iget p1, p1, Lradiant/swipe/QueueRequest;->position:I
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v2
+
+    if-eqz v2, :empty_queue
+
+    new-instance v2, Lcom/aspiro/wamp/nowplaying/view/suggestions/i$a;
+
+    invoke-direct {v2, p1}, Lcom/aspiro/wamp/nowplaying/view/suggestions/i$a;-><init>(I)V
+
+    goto :emit
+
+    :empty_queue
+    new-instance v2, Lcom/aspiro/wamp/nowplaying/view/suggestions/i$e;
+
+    invoke-direct {v2, p1}, Lcom/aspiro/wamp/nowplaying/view/suggestions/i$e;-><init>(I)V
+
+    :emit
+    invoke-interface {v1, v2}, Lcom/aspiro/wamp/nowplaying/view/suggestions/j;->a(Lcom/aspiro/wamp/nowplaying/view/suggestions/i;)V
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 5
+
+    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->recycler:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    if-ne v0, p1, :invalid
+
+    instance-of v0, p2, Lcom/aspiro/wamp/nowplaying/view/suggestions/y$a;
+
+    if-eqz v0, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+
+    move-result p2
+
+    if-gez p2, :has_position
+
+    goto :invalid
+
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+
+    move-result-object p1
+
+    instance-of v0, p1, La50/b;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, La50/b;
+
+    iget-object p1, p1, La50/b;->b:Ljava/util/ArrayList;
+
+    invoke-virtual {p1}, Ljava/util/ArrayList;->size()I
+
+    move-result v0
+
+    if-lt p2, v0, :read_item
+
+    goto :invalid
+
+    :read_item
+    invoke-virtual {p1, p2}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    instance-of v0, p1, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    if-eqz v0, :invalid
+
+    check-cast p1, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    invoke-virtual {p1}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getMediaItem()Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v1
+
+    new-instance v2, Lradiant/swipe/QueueRequest;
+
+    invoke-direct {v2, p2, p1, v1}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+
+    invoke-direct {p0, v2}, Lradiant/swipe/SuggestionsResolver;->current(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
+
+    move-result-object v3
+
+    if-eqz v3, :invalid
+
+    return-object v2
+
+    :invalid
+    const/4 p1, 0x0
+
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/SuggestionsResolver.smali
+++ b/patches/extension/radiant/swipe/SuggestionsResolver.smali
@@ -319,6 +319,10 @@
 
     iget v2, p1, Lradiant/swipe/QueueRequest;->action:I
 
+    const/4 v3, 0x3
+
+    if-eq v2, v3, :track_action
+
     const/4 v3, 0x1
 
     if-ne v2, v3, :default_action
@@ -329,6 +333,7 @@
 
     if-eqz v2, :default_action
 
+    :track_action
     invoke-virtual {v0}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getMediaItem()Lcom/aspiro/wamp/model/Track;
 
     move-result-object v2
@@ -375,7 +380,18 @@
 
     move-result-object v0
 
+    iget p1, p1, Lradiant/swipe/QueueRequest;->action:I
+
+    const/4 v3, 0x3
+
+    if-eq p1, v3, :add_to_playlist
+
     invoke-static {v0, v2, v4, v6}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :add_to_playlist
+    invoke-static {v0, v2, v4, v6}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/SuggestionsResolver.smali
+++ b/patches/extension/radiant/swipe/SuggestionsResolver.smali
@@ -303,7 +303,7 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 4
+    .locals 7
 
     invoke-direct {p0, p1}, Lradiant/swipe/SuggestionsResolver;->current(Lradiant/swipe/QueueRequest;)Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;
 
@@ -311,18 +311,75 @@
 
     if-eqz v0, :done
 
-    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
-
-    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
-
-    move-result-object v0
-
     invoke-direct {p0}, Lradiant/swipe/SuggestionsResolver;->viewModel()Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
 
     move-result-object v1
 
     if-eqz v1, :done
 
+    iget v2, p1, Lradiant/swipe/QueueRequest;->action:I
+
+    const/4 v3, 0x1
+
+    if-ne v2, v3, :default_action
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v2
+
+    if-eqz v2, :default_action
+
+    invoke-virtual {v0}, Lcom/aspiro/wamp/model/SuggestedMediaItem$SuggestedTrack;->getMediaItem()Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+
+    move-result v3
+
+    invoke-static {v3}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+
+    move-result-object v3
+
+    new-instance v4, Lcom/aspiro/wamp/model/MediaItemParent;
+
+    invoke-direct {v4, v2}, Lcom/aspiro/wamp/model/MediaItemParent;-><init>(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {v4}, Lkotlin/collections/u;->h(Ljava/lang/Object;)Ljava/util/List;
+
+    move-result-object v4
+
+    check-cast v1, Lcom/aspiro/wamp/nowplaying/view/suggestions/a1;
+
+    iget-object v5, v1, Lcom/aspiro/wamp/nowplaying/view/suggestions/a1;->j:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v3, v4, v5}, Lcom/aspiro/wamp/playqueue/source/model/b;->p(Ljava/lang/String;Ljava/util/List;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v6
+
+    new-instance v4, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    const-string v3, "suggestions"
+
+    invoke-direct {v4, v3}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;)V
+
+    iget-object v0, p0, Lradiant/swipe/SuggestionsResolver;->host:Ljava/lang/ref/WeakReference;
+
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Landroidx/fragment/app/Fragment;
+
+    invoke-virtual {v0}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+
+    move-result-object v0
+
+    invoke-static {v0, v2, v4, v6}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :default_action
     iget p1, p1, Lradiant/swipe/QueueRequest;->position:I
 
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z

--- a/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
+++ b/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
@@ -237,6 +237,8 @@
     move-object v5, v0
     check-cast v5, Lbm/k;
     iget-object v6, v5, Lbm/k;->a:Lcom/aspiro/wamp/model/Track;
+    const/4 v7, 0x3
+    if-eq v8, v7, :append_track
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
     move-result v7
     if-nez v7, :append_track
@@ -273,6 +275,10 @@
     invoke-virtual {p1, v6}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v0
+    const/4 v2, 0x3
+
+    if-eq v8, v2, :add_to_playlist_track
+
     const/4 v2, 0x1
 
     if-ne v8, v2, :queue_append_track
@@ -283,6 +289,10 @@
 
     :queue_append_track
     invoke-static {v0, v6, v3, p1}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    goto :done
+
+    :add_to_playlist_track
+    invoke-static {v0, v6, v3, p1}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
     goto :done
 
     :album
@@ -296,6 +306,10 @@
     iget-object v6, v0, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v7
+    const/4 v0, 0x3
+
+    if-eq v8, v0, :add_to_playlist_album
+
     const/4 v0, 0x1
 
     if-ne v8, v0, :append_album
@@ -312,6 +326,10 @@
     invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
     goto :done
 
+    :add_to_playlist_album
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->addToPlaylistAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
+    goto :done
+
     :playlist
     instance-of v5, v0, Lbm/g;
     if-eqz v5, :mix
@@ -319,6 +337,10 @@
     iget-object v5, v0, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v6
+    const/4 v0, 0x3
+
+    if-eq v8, v0, :add_to_playlist_playlist
+
     const/4 v0, 0x1
 
     if-ne v8, v0, :append_playlist
@@ -329,6 +351,10 @@
 
     :append_playlist
     invoke-static {v6, v5, v3, v4}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    goto :done
+
+    :add_to_playlist_playlist
+    invoke-static {v6, v5, v3, v4}, Lradiant/swipe/QueueExecutor;->addToPlaylistPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
     goto :done
 
     :mix
@@ -342,6 +368,10 @@
     iget-object v6, v0, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v7
+    const/4 v0, 0x3
+
+    if-eq v8, v0, :add_to_playlist_mix
+
     const/4 v0, 0x1
 
     if-ne v8, v0, :append_mix
@@ -356,6 +386,11 @@
     if-eqz v0, :done
     iget-object v1, v1, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->g:Lio/reactivex/disposables/CompositeDisposable;
     invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    goto :done
+
+    :add_to_playlist_mix
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->addToPlaylistMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)V
 
     :done
     return-void

--- a/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
+++ b/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
@@ -1,0 +1,416 @@
+.class public final Lradiant/swipe/UnifiedSearchResolver;
+.super Ljava/lang/Object;
+.source "UnifiedSearchResolver.smali"
+
+# interfaces
+.implements Lradiant/swipe/QueueRowResolver;
+
+# instance fields
+.field private final fragment:Ljava/lang/ref/WeakReference;
+.field private final recycler:Ljava/lang/ref/WeakReference;
+
+# direct methods
+.method private constructor <init>(Lcom/aspiro/wamp/search/v2/UnifiedSearchView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+    new-instance v0, Ljava/lang/ref/WeakReference;
+    invoke-direct {v0, p1}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+    iput-object v0, p0, Lradiant/swipe/UnifiedSearchResolver;->fragment:Ljava/lang/ref/WeakReference;
+    new-instance v0, Ljava/lang/ref/WeakReference;
+    invoke-direct {v0, p2}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+    iput-object v0, p0, Lradiant/swipe/UnifiedSearchResolver;->recycler:Ljava/lang/ref/WeakReference;
+    return-void
+.end method
+
+.method private current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    .locals 7
+
+    if-eqz p1, :invalid
+    iget-object v0, p1, Lradiant/swipe/QueueRequest;->media:Ljava/lang/Object;
+
+    iget-object v1, p0, Lradiant/swipe/UnifiedSearchResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v1
+    check-cast v1, Landroidx/recyclerview/widget/RecyclerView;
+    if-eqz v1, :invalid
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+    move-result-object v1
+    instance-of v2, v1, La50/d;
+    if-eqz v2, :invalid
+    check-cast v1, La50/d;
+    invoke-virtual {v1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+    move-result-object v1
+
+    iget v2, p1, Lradiant/swipe/QueueRequest;->position:I
+    if-gez v2, :check_size
+    goto :invalid
+    :check_size
+    invoke-interface {v1}, Ljava/util/List;->size()I
+    move-result v3
+    if-lt v2, v3, :read_item
+    goto :invalid
+    :read_item
+    invoke-interface {v1, v2}, Ljava/util/List;->get(I)Ljava/lang/Object;
+    move-result-object v1
+
+    instance-of v2, v0, Lbm/k;
+    if-eqz v2, :album
+    instance-of v2, v1, Lbm/k;
+    if-eqz v2, :invalid
+    move-object v2, v0
+    check-cast v2, Lbm/k;
+    move-object v3, v1
+    check-cast v3, Lbm/k;
+    iget-object v4, v3, Lbm/k;->e:Lcom/aspiro/wamp/model/Availability$MediaItem;
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
+    move-result v4
+    if-eqz v4, :invalid
+    iget-object v2, v2, Lbm/k;->a:Lcom/aspiro/wamp/model/Track;
+    iget-object v3, v3, Lbm/k;->a:Lcom/aspiro/wamp/model/Track;
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v2
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v3
+    if-ne v2, v3, :invalid
+    iget v4, p1, Lradiant/swipe/QueueRequest;->id:I
+    if-ne v3, v4, :invalid
+    return-object v1
+
+    :album
+    instance-of v2, v0, Lbm/a;
+    if-eqz v2, :playlist
+    instance-of v2, v1, Lbm/a;
+    if-eqz v2, :invalid
+    move-object v2, v0
+    check-cast v2, Lbm/a;
+    move-object v3, v1
+    check-cast v3, Lbm/a;
+    iget-object v4, v3, Lbm/a;->c:Lcom/aspiro/wamp/model/Availability$Album;
+    invoke-virtual {v4}, Lcom/aspiro/wamp/model/Availability$Album;->isAvailable()Z
+    move-result v4
+    if-eqz v4, :invalid
+    iget-object v2, v2, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
+    iget-object v3, v3, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Album;->getId()I
+    move-result v2
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/Album;->getId()I
+    move-result v3
+    if-ne v2, v3, :invalid
+    iget v4, p1, Lradiant/swipe/QueueRequest;->id:I
+    if-ne v3, v4, :invalid
+    return-object v1
+
+    :playlist
+    instance-of v2, v0, Lbm/g;
+    if-eqz v2, :mix
+    instance-of v2, v1, Lbm/g;
+    if-eqz v2, :invalid
+    move-object v2, v0
+    check-cast v2, Lbm/g;
+    move-object v3, v1
+    check-cast v3, Lbm/g;
+    iget-object v2, v2, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
+    iget-object v3, v3, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/Playlist;->getNumberOfItems()I
+    move-result v4
+    if-lez v4, :invalid
+    const-string v4, "NOT_READY"
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/Playlist;->getStatus()Ljava/lang/String;
+    move-result-object v5
+    invoke-virtual {v4, v5}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+    move-result v4
+    if-nez v4, :invalid
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+    move-result-object v2
+    invoke-virtual {v3}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+    move-result-object v3
+    invoke-virtual {v2, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+    move-result v2
+    if-eqz v2, :invalid
+    invoke-virtual {v3}, Ljava/lang/String;->hashCode()I
+    move-result v2
+    iget v4, p1, Lradiant/swipe/QueueRequest;->id:I
+    if-ne v2, v4, :invalid
+
+    iget-object v2, p0, Lradiant/swipe/UnifiedSearchResolver;->fragment:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v2
+    check-cast v2, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;
+    if-eqz v2, :invalid
+    invoke-virtual {v2}, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->N()Ltl/h;
+    move-result-object v2
+    instance-of v4, v2, Lcom/aspiro/wamp/search/v2/d;
+    if-eqz v4, :invalid
+    check-cast v2, Lcom/aspiro/wamp/search/v2/d;
+    iget-object v2, v2, Lcom/aspiro/wamp/search/v2/d;->e:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+    invoke-static {v3}, Ljava/util/UUID;->fromString(Ljava/lang/String;)Ljava/util/UUID;
+    move-result-object v3
+    invoke-interface {v2, v3}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getPlaylistAvailability(Ljava/util/UUID;)Lcom/aspiro/wamp/model/Availability$Playlist;
+    move-result-object v2
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Availability$Playlist;->isAvailable()Z
+    move-result v2
+    if-eqz v2, :invalid
+    return-object v1
+
+    :mix
+    instance-of v2, v0, Lbm/f;
+    if-eqz v2, :invalid
+    instance-of v2, v1, Lbm/f;
+    if-eqz v2, :invalid
+    move-object v2, v0
+    check-cast v2, Lbm/f;
+    move-object v3, v1
+    check-cast v3, Lbm/f;
+    iget-object v2, v2, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
+    iget-object v3, v3, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
+    invoke-virtual {v2}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+    move-result-object v2
+    invoke-virtual {v3}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+    move-result-object v3
+    invoke-virtual {v2, v3}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+    move-result v2
+    if-eqz v2, :invalid
+    invoke-virtual {v3}, Ljava/lang/String;->hashCode()I
+    move-result v2
+    iget v4, p1, Lradiant/swipe/QueueRequest;->id:I
+    if-ne v2, v4, :invalid
+
+    iget-object v2, p0, Lradiant/swipe/UnifiedSearchResolver;->fragment:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v2}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v2
+    check-cast v2, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;
+    if-eqz v2, :invalid
+    invoke-virtual {v2}, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->N()Ltl/h;
+    move-result-object v2
+    instance-of v4, v2, Lcom/aspiro/wamp/search/v2/d;
+    if-eqz v4, :invalid
+    check-cast v2, Lcom/aspiro/wamp/search/v2/d;
+    iget-object v2, v2, Lcom/aspiro/wamp/search/v2/d;->e:Lcom/aspiro/wamp/model/AvailabilityInteractor;
+    invoke-interface {v2, v3}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getMixAvailability(Ljava/lang/String;)Lcom/aspiro/wamp/model/Availability$Mix;
+    move-result-object v2
+    invoke-virtual {v2}, Lcom/aspiro/wamp/model/Availability$Mix;->isAvailable()Z
+    move-result v2
+    if-eqz v2, :invalid
+    return-object v1
+
+    :invalid
+    const/4 v0, 0x0
+    return-object v0
+.end method
+
+.method public static install(Lcom/aspiro/wamp/search/v2/UnifiedSearchView;Landroidx/recyclerview/widget/RecyclerView;)V
+    .locals 1
+    if-eqz p0, :done
+    if-eqz p1, :done
+    new-instance v0, Lradiant/swipe/UnifiedSearchResolver;
+    invoke-direct {v0, p0, p1}, Lradiant/swipe/UnifiedSearchResolver;-><init>(Lcom/aspiro/wamp/search/v2/UnifiedSearchView;Landroidx/recyclerview/widget/RecyclerView;)V
+    invoke-static {p1, v0}, Lradiant/SwipeToQueue;->install(Landroidx/recyclerview/widget/RecyclerView;Lradiant/swipe/QueueRowResolver;)V
+    :done
+    return-void
+.end method
+
+# virtual methods
+.method public execute(Lradiant/swipe/QueueRequest;)V
+    .locals 8
+
+    invoke-direct {p0, p1}, Lradiant/swipe/UnifiedSearchResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    move-result-object v0
+    if-eqz v0, :done
+
+    iget-object v1, p0, Lradiant/swipe/UnifiedSearchResolver;->fragment:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v1}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v1
+    check-cast v1, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;
+    if-eqz v1, :done
+    iget-object v2, v1, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->c:Ltl/q;
+    if-eqz v2, :done
+
+    invoke-static {v0}, Lbm/i;->a(Lbm/h;)Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+    move-result-object v3
+    iget-object v4, v2, Ltl/q;->c:Lcom/tidal/android/navigation/NavigationInfo;
+
+    instance-of v5, v0, Lbm/k;
+    if-eqz v5, :album
+    move-object v5, v0
+    check-cast v5, Lbm/k;
+    iget-object v6, v5, Lbm/k;->a:Lcom/aspiro/wamp/model/Track;
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+    move-result v7
+    if-nez v7, :append_track
+    new-instance v2, Lcom/aspiro/wamp/search/v2/a$g;
+    iget v3, p1, Lradiant/swipe/QueueRequest;->position:I
+    invoke-direct {v2, v0, v3}, Lcom/aspiro/wamp/search/v2/a$g;-><init>(Lbm/h;I)V
+    invoke-virtual {v1}, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->N()Ltl/h;
+    move-result-object v0
+    invoke-interface {v0, v2}, Ltl/f;->e(Lcom/aspiro/wamp/search/v2/a;)V
+    goto :done
+
+    :append_track
+    const-string v7, ""
+    iget-object p1, v5, Lbm/k;->n:Lcom/aspiro/wamp/search/SearchDataSource;
+    sget-object v0, Lcom/aspiro/wamp/search/SearchDataSource;->REMOTE:Lcom/aspiro/wamp/search/SearchDataSource;
+    if-ne p1, v0, :query_ready
+    invoke-virtual {v1}, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->N()Ltl/h;
+    move-result-object p1
+    invoke-interface {p1}, Ltl/h;->c()Lcom/aspiro/wamp/search/v2/model/UnifiedSearchQuery;
+    move-result-object p1
+    iget-object v7, p1, Lcom/aspiro/wamp/search/v2/model/UnifiedSearchQuery;->a:Ljava/lang/String;
+    :query_ready
+    invoke-virtual {v6}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result p1
+    invoke-static {p1}, Ljava/lang/String;->valueOf(I)Ljava/lang/String;
+    move-result-object p1
+    const/4 v0, 0x0
+    if-eqz v4, :nav_ready
+    invoke-static {v4}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+    move-result-object v0
+    :nav_ready
+    invoke-static {p1, v7, v0}, Lcom/aspiro/wamp/playqueue/source/model/b;->o(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+    move-result-object p1
+    invoke-virtual {p1, v6}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+    move-result-object v0
+    invoke-static {v0, v6, v3, p1}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+    goto :done
+
+    :album
+    instance-of v5, v0, Lbm/a;
+    if-eqz v5, :playlist
+    iget-object v5, v2, Ltl/q;->a:Lx40/a;
+    instance-of v6, v5, Lh4/a;
+    if-eqz v6, :done
+    check-cast v5, Lh4/a;
+    check-cast v0, Lbm/a;
+    iget-object v6, v0, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+    move-result-object v7
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    move-result-object v0
+    if-eqz v0, :done
+    iget-object v1, v1, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->g:Lio/reactivex/disposables/CompositeDisposable;
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+    goto :done
+
+    :playlist
+    instance-of v5, v0, Lbm/g;
+    if-eqz v5, :mix
+    check-cast v0, Lbm/g;
+    iget-object v5, v0, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+    move-result-object v6
+    invoke-static {v6, v5, v3, v4}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+    goto :done
+
+    :mix
+    instance-of v5, v0, Lbm/f;
+    if-eqz v5, :done
+    iget-object v5, v2, Ltl/q;->a:Lx40/a;
+    instance-of v6, v5, Lh4/a;
+    if-eqz v6, :done
+    check-cast v5, Lh4/a;
+    check-cast v0, Lbm/f;
+    iget-object v6, v0, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
+    invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
+    move-result-object v7
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+    move-result-object v0
+    if-eqz v0, :done
+    iget-object v1, v1, Lcom/aspiro/wamp/search/v2/UnifiedSearchView;->g:Lio/reactivex/disposables/CompositeDisposable;
+    invoke-virtual {v1, v0}, Lio/reactivex/disposables/CompositeDisposable;->add(Lio/reactivex/disposables/Disposable;)Z
+
+    :done
+    return-void
+.end method
+
+.method public resolve(Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)Lradiant/swipe/QueueRequest;
+    .locals 6
+
+    iget-object v0, p0, Lradiant/swipe/UnifiedSearchResolver;->recycler:Ljava/lang/ref/WeakReference;
+    invoke-virtual {v0}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+    move-result-object v0
+    if-ne v0, p1, :invalid
+
+    invoke-virtual {p2}, Landroidx/recyclerview/widget/RecyclerView$ViewHolder;->getBindingAdapterPosition()I
+    move-result v0
+    const/4 v1, -0x1
+    if-ne v0, v1, :has_position
+    goto :invalid
+    :has_position
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/RecyclerView;->getAdapter()Landroidx/recyclerview/widget/RecyclerView$Adapter;
+    move-result-object p1
+    instance-of v1, p1, La50/d;
+    if-eqz v1, :invalid
+    check-cast p1, La50/d;
+    invoke-virtual {p1}, Landroidx/recyclerview/widget/ListAdapter;->getCurrentList()Ljava/util/List;
+    move-result-object p1
+    invoke-interface {p1}, Ljava/util/List;->size()I
+    move-result v1
+    if-lt v0, v1, :read_item
+    goto :invalid
+    :read_item
+    invoke-interface {p1, v0}, Ljava/util/List;->get(I)Ljava/lang/Object;
+    move-result-object p1
+
+    instance-of v1, p2, Lul/n0$a;
+    if-eqz v1, :album_holder
+    instance-of v1, p1, Lbm/k;
+    if-eqz v1, :invalid
+    move-object v1, p1
+    check-cast v1, Lbm/k;
+    iget-object v1, v1, Lbm/k;->a:Lcom/aspiro/wamp/model/Track;
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
+    move-result v1
+    goto :create
+
+    :album_holder
+    instance-of v1, p2, Lul/d$a;
+    if-eqz v1, :playlist_holder
+    instance-of v1, p1, Lbm/a;
+    if-eqz v1, :invalid
+    move-object v1, p1
+    check-cast v1, Lbm/a;
+    iget-object v1, v1, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Album;->getId()I
+    move-result v1
+    goto :create
+
+    :playlist_holder
+    instance-of v1, p2, Lul/a0$a;
+    if-eqz v1, :mix_holder
+    instance-of v1, p1, Lbm/g;
+    if-eqz v1, :invalid
+    move-object v1, p1
+    check-cast v1, Lbm/g;
+    iget-object v1, v1, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
+    invoke-virtual {v1}, Lcom/aspiro/wamp/model/Playlist;->getUuid()Ljava/lang/String;
+    move-result-object v1
+    invoke-virtual {v1}, Ljava/lang/String;->hashCode()I
+    move-result v1
+    goto :create
+
+    :mix_holder
+    instance-of p2, p2, Lul/w$a;
+    if-eqz p2, :invalid
+    instance-of p2, p1, Lbm/f;
+    if-eqz p2, :invalid
+    move-object p2, p1
+    check-cast p2, Lbm/f;
+    iget-object p2, p2, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
+    invoke-virtual {p2}, Lcom/aspiro/wamp/mix/model/Mix;->getId()Ljava/lang/String;
+    move-result-object p2
+    invoke-virtual {p2}, Ljava/lang/String;->hashCode()I
+    move-result v1
+
+    :create
+    new-instance v2, Lradiant/swipe/QueueRequest;
+    invoke-direct {v2, v0, p1, v1}, Lradiant/swipe/QueueRequest;-><init>(ILjava/lang/Object;I)V
+    invoke-direct {p0, v2}, Lradiant/swipe/UnifiedSearchResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
+    move-result-object p1
+    if-eqz p1, :invalid
+    return-object v2
+
+    :invalid
+    const/4 p1, 0x0
+    return-object p1
+.end method

--- a/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
+++ b/patches/extension/radiant/swipe/UnifiedSearchResolver.smali
@@ -212,7 +212,9 @@
 
 # virtual methods
 .method public execute(Lradiant/swipe/QueueRequest;)V
-    .locals 8
+    .locals 9
+
+    iget v8, p1, Lradiant/swipe/QueueRequest;->action:I
 
     invoke-direct {p0, p1}, Lradiant/swipe/UnifiedSearchResolver;->current(Lradiant/swipe/QueueRequest;)Ljava/lang/Object;
     move-result-object v0
@@ -271,6 +273,15 @@
     invoke-virtual {p1, v6}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v0
+    const/4 v2, 0x1
+
+    if-ne v8, v2, :queue_append_track
+
+    invoke-static {v0, v6, v3, p1}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :queue_append_track
     invoke-static {v0, v6, v3, p1}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
     goto :done
 
@@ -285,6 +296,15 @@
     iget-object v6, v0, Lbm/a;->a:Lcom/aspiro/wamp/model/Album;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v7
+    const/4 v0, 0x1
+
+    if-ne v8, v0, :append_album
+
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playNextAlbum(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_album
     invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->album(Landroid/content/Context;Lcom/aspiro/wamp/model/Album;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
     move-result-object v0
     if-eqz v0, :done
@@ -299,6 +319,15 @@
     iget-object v5, v0, Lbm/g;->a:Lcom/aspiro/wamp/model/Playlist;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v6
+    const/4 v0, 0x1
+
+    if-ne v8, v0, :append_playlist
+
+    invoke-static {v6, v5, v3, v4}, Lradiant/swipe/QueueExecutor;->playNextPlaylist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
+
+    goto :done
+
+    :append_playlist
     invoke-static {v6, v5, v3, v4}, Lradiant/swipe/QueueExecutor;->playlist(Landroid/content/Context;Lcom/aspiro/wamp/model/Playlist;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;)V
     goto :done
 
@@ -313,6 +342,15 @@
     iget-object v6, v0, Lbm/f;->a:Lcom/aspiro/wamp/mix/model/Mix;
     invoke-virtual {v1}, Landroidx/fragment/app/Fragment;->getContext()Landroid/content/Context;
     move-result-object v7
+    const/4 v0, 0x1
+
+    if-ne v8, v0, :append_mix
+
+    invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->playNextMix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
+
+    goto :done
+
+    :append_mix
     invoke-static {v7, v6, v3, v4, v5}, Lradiant/swipe/QueueExecutor;->mix(Landroid/content/Context;Lcom/aspiro/wamp/mix/model/Mix;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/tidal/android/navigation/NavigationInfo;Lh4/a;)Lio/reactivex/disposables/Disposable;
     move-result-object v0
     if-eqz v0, :done

--- a/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
@@ -213,6 +213,10 @@
 
     if-eqz v5, :done
 
+    const/4 v1, 0x3
+
+    if-eq p1, v1, :queue_event
+
     const/4 v1, 0x4
 
     if-ne v5, v1, :queue_event

--- a/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
@@ -1,0 +1,310 @@
+.class public final Lradiant/swipe/VerticalMediaQueueAction;
+.super Ljava/lang/Object;
+.source "VerticalMediaQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# static fields
+.field public static final TYPE_ALBUM:I = 0x1
+
+.field public static final TYPE_MIX:I = 0x2
+
+.field public static final TYPE_PLAYLIST:I = 0x3
+
+.field public static final TYPE_TRACK:I = 0x4
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final itemId:Ljava/lang/String;
+
+.field private final mediaType:I
+
+.field private final moduleUuid:Ljava/lang/String;
+
+.field private final pageId:Ljava/lang/String;
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e;)V
+    .locals 3
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/VerticalMediaQueueAction;->callback:Lam0/l;
+
+    iput-object p2, p0, Lradiant/swipe/VerticalMediaQueueAction;->pageId:Ljava/lang/String;
+
+    iput-object p3, p0, Lradiant/swipe/VerticalMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    instance-of v0, p4, Lm40/e$a;
+
+    if-eqz v0, :mix
+
+    check-cast p4, Lm40/e$a;
+
+    iget-wide v0, p4, Lm40/e$a;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v0
+
+    const/4 v1, 0x1
+
+    goto :store
+
+    :mix
+    instance-of v0, p4, Lm40/e$c;
+
+    if-eqz v0, :playlist
+
+    check-cast p4, Lm40/e$c;
+
+    iget-object v0, p4, Lm40/e$c;->a:Ljava/lang/String;
+
+    const/4 v1, 0x2
+
+    goto :store
+
+    :playlist
+    instance-of v0, p4, Lm40/e$d;
+
+    if-eqz v0, :track
+
+    check-cast p4, Lm40/e$d;
+
+    iget-object v0, p4, Lm40/e$d;->a:Ljava/lang/String;
+
+    const/4 v1, 0x3
+
+    goto :store
+
+    :track
+    instance-of v0, p4, Lm40/e$e;
+
+    if-eqz v0, :unsupported
+
+    check-cast p4, Lm40/e$e;
+
+    iget-wide v0, p4, Lm40/e$e;->a:J
+
+    invoke-static {v0, v1}, Ljava/lang/String;->valueOf(J)Ljava/lang/String;
+
+    move-result-object v0
+
+    const/4 v1, 0x4
+
+    goto :store
+
+    :unsupported
+    const/4 v0, 0x0
+
+    const/4 v1, 0x0
+
+    :store
+    iput-object v0, p0, Lradiant/swipe/VerticalMediaQueueAction;->itemId:Ljava/lang/String;
+
+    iput v1, p0, Lradiant/swipe/VerticalMediaQueueAction;->mediaType:I
+
+    return-void
+.end method
+
+.method public static isEligible(Lm40/e;)Z
+    .locals 1
+
+    instance-of v0, p0, Lm40/e$a;
+
+    if-eqz v0, :mix
+
+    check-cast p0, Lm40/e$a;
+
+    iget-boolean p0, p0, Lm40/e$a;->e:Z
+
+    return p0
+
+    :mix
+    instance-of v0, p0, Lm40/e$c;
+
+    if-eqz v0, :playlist
+
+    check-cast p0, Lm40/e$c;
+
+    iget-boolean p0, p0, Lm40/e$c;->h:Z
+
+    return p0
+
+    :playlist
+    instance-of v0, p0, Lm40/e$d;
+
+    if-eqz v0, :track
+
+    check-cast p0, Lm40/e$d;
+
+    iget-boolean p0, p0, Lm40/e$d;->g:Z
+
+    return p0
+
+    :track
+    instance-of v0, p0, Lm40/e$e;
+
+    if-eqz v0, :invalid
+
+    check-cast p0, Lm40/e$e;
+
+    iget-boolean p0, p0, Lm40/e$e;->j:Z
+
+    return p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return p0
+.end method
+
+.method public static isSupported(Lm40/e;)Z
+    .locals 1
+
+    instance-of v0, p0, Lm40/e$a;
+
+    if-nez v0, :supported
+
+    instance-of v0, p0, Lm40/e$c;
+
+    if-nez v0, :supported
+
+    instance-of v0, p0, Lm40/e$d;
+
+    if-nez v0, :supported
+
+    instance-of v0, p0, Lm40/e$e;
+
+    if-eqz v0, :invalid
+
+    :supported
+    const/4 p0, 0x1
+
+    return p0
+
+    :invalid
+    const/4 p0, 0x0
+
+    return p0
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 7
+
+    iget-object v6, p0, Lradiant/swipe/VerticalMediaQueueAction;->callback:Lam0/l;
+
+    if-eqz v6, :done
+
+    iget-object v4, p0, Lradiant/swipe/VerticalMediaQueueAction;->itemId:Ljava/lang/String;
+
+    if-eqz v4, :done
+
+    iget v5, p0, Lradiant/swipe/VerticalMediaQueueAction;->mediaType:I
+
+    if-eqz v5, :done
+
+    const/4 v1, 0x4
+
+    if-ne v5, v1, :queue_event
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v1
+
+    if-nez v1, :queue_event
+
+    new-instance v1, Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/b$a;
+
+    iget-object v2, p0, Lradiant/swipe/VerticalMediaQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/VerticalMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-direct {v1, v2, v3, v4}, Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/b$a;-><init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+
+    goto :emit
+
+    :queue_event
+
+    iget-object v1, p0, Lradiant/swipe/VerticalMediaQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v1, :done
+
+    new-instance v0, Lradiant/swipe/DynamicMediaQueueEvent;
+
+    iget-object v2, p0, Lradiant/swipe/VerticalMediaQueueAction;->pageId:Ljava/lang/String;
+
+    iget-object v3, p0, Lradiant/swipe/VerticalMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+
+    move-object v1, v0
+
+    :emit
+    invoke-interface {v6, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/VerticalMediaQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method
+
+.method public stableKey()Ljava/lang/String;
+    .locals 3
+
+    iget-object v0, p0, Lradiant/swipe/VerticalMediaQueueAction;->itemId:Ljava/lang/String;
+
+    if-eqz v0, :invalid
+
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    const-string v2, "vlc:"
+
+    invoke-direct {v1, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    iget-object v2, p0, Lradiant/swipe/VerticalMediaQueueAction;->moduleUuid:Ljava/lang/String;
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    const/16 v2, 0x3a
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    iget v2, p0, Lradiant/swipe/VerticalMediaQueueAction;->mediaType:I
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+
+    const/16 v2, 0x3a
+
+    invoke-virtual {v1, v2}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+
+    :invalid
+    const/4 v0, 0x0
+
+    return-object v0
+.end method

--- a/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
+++ b/patches/extension/radiant/swipe/VerticalMediaQueueAction.smali
@@ -198,12 +198,12 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
-    .locals 7
+.method public invoke(I)Ljava/lang/Object;
+    .locals 8
 
-    iget-object v6, p0, Lradiant/swipe/VerticalMediaQueueAction;->callback:Lam0/l;
+    iget-object v7, p0, Lradiant/swipe/VerticalMediaQueueAction;->callback:Lam0/l;
 
-    if-eqz v6, :done
+    if-eqz v7, :done
 
     iget-object v4, p0, Lradiant/swipe/VerticalMediaQueueAction;->itemId:Ljava/lang/String;
 
@@ -245,15 +245,29 @@
 
     iget-object v3, p0, Lradiant/swipe/VerticalMediaQueueAction;->moduleUuid:Ljava/lang/String;
 
-    invoke-direct/range {v0 .. v5}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+    move v6, p1
+
+    invoke-direct/range {v0 .. v6}, Lradiant/swipe/DynamicMediaQueueEvent;-><init>(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
 
     move-object v1, v0
 
     :emit
-    invoke-interface {v6, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+    invoke-interface {v7, v1}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/VerticalMediaQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
@@ -103,9 +103,18 @@
 
     const/4 v0, 0x1
 
-    if-ne p4, v0, :append
+    if-ne p4, v0, :check_add_to_playlist
 
     invoke-static {p1, v3, v4, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :check_add_to_playlist
+    const/4 v0, 0x3
+
+    if-ne p4, v0, :append
+
+    invoke-static {p1, v3, v4, v9}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
 
     goto :done
 

--- a/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
@@ -8,7 +8,7 @@
 
 
 # direct methods
-.method public static handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;J)V
+.method public static handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;JI)V
     .locals 10
 
     if-eqz p0, :done
@@ -101,6 +101,15 @@
 
     invoke-virtual {v9, v3}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
 
+    const/4 v0, 0x1
+
+    if-ne p4, v0, :append
+
+    invoke-static {p1, v3, v4, v9}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    goto :done
+
+    :append
     invoke-static {p1, v3, v4, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 
     :done
@@ -108,7 +117,7 @@
 .end method
 
 .method public static handleEvent(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Lcom/tidal/android/feature/viewall/ui/e;)Z
-    .locals 5
+    .locals 6
 
     instance-of v0, p1, Lcom/tidal/android/feature/viewall/ui/e$c;
 
@@ -138,15 +147,39 @@
 
     move-result-object v0
 
+    const/16 v1, 0x3a
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->indexOf(I)I
+
+    move-result v1
+
+    if-lez v1, :not_handled
+
+    const/4 v2, 0x0
+
+    invoke-virtual {v0, v2, v1}, Ljava/lang/String;->substring(II)Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-static {v2}, Ljava/lang/Integer;->parseInt(Ljava/lang/String;)I
+
+    move-result v4
+
+    add-int/lit8 v1, v1, 0x1
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->substring(I)Ljava/lang/String;
+
+    move-result-object v0
+
     invoke-static {v0}, Ljava/lang/Long;->parseLong(Ljava/lang/String;)J
 
     move-result-wide v1
 
     sget-object v3, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
 
-    const/4 v4, 0x0
+    const/4 v5, 0x0
 
-    sput-object v4, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
+    sput-object v5, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
 
     if-eqz v3, :handled
 
@@ -156,7 +189,7 @@
 
     check-cast v3, Landroid/content/Context;
 
-    invoke-static {p0, v3, v1, v2}, Lradiant/swipe/ViewAllTrackQueue;->handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;J)V
+    invoke-static {p0, v3, v1, v2, v4}, Lradiant/swipe/ViewAllTrackQueue;->handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;JI)V
 
     :handled
     const/4 v0, 0x1
@@ -169,7 +202,7 @@
     return v0
 .end method
 
-.method public static marker(J)Ljava/lang/String;
+.method public static marker(JI)Ljava/lang/String;
     .locals 2
 
     new-instance v0, Ljava/lang/StringBuilder;
@@ -177,6 +210,12 @@
     const-string v1, "rl-swipe:"
 
     invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v0, p2}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+
+    const/16 v1, 0x3a
+
+    invoke-virtual {v0, v1}, Ljava/lang/StringBuilder;->append(C)Ljava/lang/StringBuilder;
 
     invoke-virtual {v0, p0, p1}, Ljava/lang/StringBuilder;->append(J)Ljava/lang/StringBuilder;
 

--- a/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueue.smali
@@ -1,0 +1,200 @@
+.class public final Lradiant/swipe/ViewAllTrackQueue;
+.super Ljava/lang/Object;
+.source "ViewAllTrackQueue.smali"
+
+
+# static fields
+.field private static context:Ljava/lang/ref/WeakReference;
+
+
+# direct methods
+.method public static handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;J)V
+    .locals 10
+
+    if-eqz p0, :done
+
+    if-eqz p1, :done
+
+    const-wide/16 v0, 0x0
+
+    cmp-long v2, p2, v0
+
+    if-lez v2, :done
+
+    iget-object v0, p0, Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;->n:Lcom/tidal/android/feature/viewall/ui/c;
+
+    iget-object v0, v0, Lcom/tidal/android/feature/viewall/ui/c;->f:Ljava/util/ArrayList;
+
+    invoke-virtual {v0}, Ljava/util/ArrayList;->iterator()Ljava/util/Iterator;
+
+    move-result-object v0
+
+    :find_track
+    invoke-interface {v0}, Ljava/util/Iterator;->hasNext()Z
+
+    move-result v2
+
+    if-eqz v2, :done
+
+    invoke-interface {v0}, Ljava/util/Iterator;->next()Ljava/lang/Object;
+
+    move-result-object v1
+
+    instance-of v2, v1, Lpd0/a;
+
+    if-eqz v2, :find_track
+
+    check-cast v1, Lpd0/a;
+
+    iget-object v1, v1, Lpd0/a;->a:Lh40/n;
+
+    instance-of v2, v1, Lh40/p;
+
+    if-eqz v2, :find_track
+
+    check-cast v1, Lh40/p;
+
+    iget-wide v3, v1, Lh40/p;->a:J
+
+    cmp-long v2, v3, p2
+
+    if-nez v2, :find_track
+
+    iget-object v0, p0, Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;->f:Lcom/tidal/android/feature/viewall/ui/u;
+
+    instance-of v2, v0, Lra/d;
+
+    if-eqz v2, :done
+
+    check-cast v0, Lra/d;
+
+    iget-object v2, v0, Lra/d;->b:Lcom/tidal/android/navigation/NavigationInfo;
+
+    invoke-static {v1}, Lie0/i;->a(Lh40/p;)Lcom/aspiro/wamp/model/Track;
+
+    move-result-object v3
+
+    if-eqz v3, :done
+
+    const-string v5, "null"
+
+    new-instance v4, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
+
+    invoke-direct {v4, v5, v5}, Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;-><init>(Ljava/lang/String;Ljava/lang/String;)V
+
+    const/4 v6, 0x0
+
+    if-eqz v2, :navigation_ready
+
+    invoke-static {v2}, Lcom/tidal/android/navigation/a;->b(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/tidal/android/navigation/NavigationInfo$Node;
+
+    move-result-object v6
+
+    :navigation_ready
+    sget-object v7, Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$None;->INSTANCE:Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType$None;
+
+    const/4 v8, 0x0
+
+    invoke-static {v5, v8, v6, v7}, Lcom/aspiro/wamp/playqueue/source/model/b;->j(Ljava/lang/String;Ljava/lang/String;Lcom/tidal/android/navigation/NavigationInfo;Lcom/aspiro/wamp/playqueue/source/model/ItemSource$NavigationType;)Lcom/aspiro/wamp/playqueue/source/model/ItemSource;
+
+    move-result-object v9
+
+    invoke-virtual {v9, v3}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
+
+    invoke-static {p1, v3, v4, v9}, Lradiant/swipe/QueueExecutor;->track(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
+
+    :done
+    return-void
+.end method
+
+.method public static handleEvent(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Lcom/tidal/android/feature/viewall/ui/e;)Z
+    .locals 5
+
+    instance-of v0, p1, Lcom/tidal/android/feature/viewall/ui/e$c;
+
+    if-eqz v0, :not_handled
+
+    check-cast p1, Lcom/tidal/android/feature/viewall/ui/e$c;
+
+    iget-object v0, p1, Lcom/tidal/android/feature/viewall/ui/e$c;->a:Ljava/lang/Object;
+
+    instance-of v1, v0, Ljava/lang/String;
+
+    if-eqz v1, :not_handled
+
+    check-cast v0, Ljava/lang/String;
+
+    const-string v1, "rl-swipe:"
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+
+    move-result v2
+
+    if-eqz v2, :not_handled
+
+    const/16 v1, 0x9
+
+    invoke-virtual {v0, v1}, Ljava/lang/String;->substring(I)Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-static {v0}, Ljava/lang/Long;->parseLong(Ljava/lang/String;)J
+
+    move-result-wide v1
+
+    sget-object v3, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
+
+    const/4 v4, 0x0
+
+    sput-object v4, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
+
+    if-eqz v3, :handled
+
+    invoke-virtual {v3}, Ljava/lang/ref/Reference;->get()Ljava/lang/Object;
+
+    move-result-object v3
+
+    check-cast v3, Landroid/content/Context;
+
+    invoke-static {p0, v3, v1, v2}, Lradiant/swipe/ViewAllTrackQueue;->handle(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Landroid/content/Context;J)V
+
+    :handled
+    const/4 v0, 0x1
+
+    return v0
+
+    :not_handled
+    const/4 v0, 0x0
+
+    return v0
+.end method
+
+.method public static marker(J)Ljava/lang/String;
+    .locals 2
+
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    const-string v1, "rl-swipe:"
+
+    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v0, p0, p1}, Ljava/lang/StringBuilder;->append(J)Ljava/lang/StringBuilder;
+
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+.end method
+
+.method public static setContext(Landroid/content/Context;)V
+    .locals 1
+
+    new-instance v0, Ljava/lang/ref/WeakReference;
+
+    invoke-direct {v0, p0}, Ljava/lang/ref/WeakReference;-><init>(Ljava/lang/Object;)V
+
+    sput-object v0, Lradiant/swipe/ViewAllTrackQueue;->context:Ljava/lang/ref/WeakReference;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
@@ -1,0 +1,89 @@
+.class public final Lradiant/swipe/ViewAllTrackQueueAction;
+.super Ljava/lang/Object;
+.source "ViewAllTrackQueueAction.smali"
+
+# interfaces
+.implements Lradiant/swipe/ComposeSwipeAction;
+
+
+# instance fields
+.field private final callback:Lam0/l;
+
+.field private context:Landroid/content/Context;
+
+.field private final trackId:J
+
+
+# direct methods
+.method public constructor <init>(Lam0/l;Lm40/e$e;)V
+    .locals 2
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lradiant/swipe/ViewAllTrackQueueAction;->callback:Lam0/l;
+
+    iget-wide v0, p2, Lm40/e$e;->a:J
+
+    iput-wide v0, p0, Lradiant/swipe/ViewAllTrackQueueAction;->trackId:J
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public invoke()Ljava/lang/Object;
+    .locals 5
+
+    iget-object v0, p0, Lradiant/swipe/ViewAllTrackQueueAction;->callback:Lam0/l;
+
+    if-eqz v0, :done
+
+    iget-wide v1, p0, Lradiant/swipe/ViewAllTrackQueueAction;->trackId:J
+
+    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
+
+    move-result v3
+
+    if-eqz v3, :play_existing
+
+    iget-object v3, p0, Lradiant/swipe/ViewAllTrackQueueAction;->context:Landroid/content/Context;
+
+    if-eqz v3, :done
+
+    invoke-static {v3}, Lradiant/swipe/ViewAllTrackQueue;->setContext(Landroid/content/Context;)V
+
+    invoke-static {v1, v2}, Lradiant/swipe/ViewAllTrackQueue;->marker(J)Ljava/lang/String;
+
+    move-result-object v3
+
+    new-instance v4, Li40/c$b;
+
+    invoke-direct {v4, v3}, Li40/c$b;-><init>(Ljava/lang/Object;)V
+
+    goto :emit
+
+    :play_existing
+    invoke-static {v1, v2}, Ljava/lang/Long;->valueOf(J)Ljava/lang/Long;
+
+    move-result-object v3
+
+    new-instance v4, Li40/c$b;
+
+    invoke-direct {v4, v3}, Li40/c$b;-><init>(Ljava/lang/Object;)V
+
+    :emit
+    invoke-interface {v0, v4}, Lam0/l;->invoke(Ljava/lang/Object;)Ljava/lang/Object;
+
+    :done
+    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public setContext(Landroid/content/Context;)V
+    .locals 0
+
+    iput-object p1, p0, Lradiant/swipe/ViewAllTrackQueueAction;->context:Landroid/content/Context;
+
+    return-void
+.end method

--- a/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
@@ -31,7 +31,7 @@
 
 
 # virtual methods
-.method public invoke()Ljava/lang/Object;
+.method public invoke(I)Ljava/lang/Object;
     .locals 5
 
     iget-object v0, p0, Lradiant/swipe/ViewAllTrackQueueAction;->callback:Lam0/l;
@@ -52,7 +52,7 @@
 
     invoke-static {v3}, Lradiant/swipe/ViewAllTrackQueue;->setContext(Landroid/content/Context;)V
 
-    invoke-static {v1, v2}, Lradiant/swipe/ViewAllTrackQueue;->marker(J)Ljava/lang/String;
+    invoke-static {v1, v2, p1}, Lradiant/swipe/ViewAllTrackQueue;->marker(JI)Ljava/lang/String;
 
     move-result-object v3
 
@@ -76,6 +76,18 @@
 
     :done
     sget-object v0, Lkotlin/u;->a:Lkotlin/u;
+
+    return-object v0
+.end method
+
+.method public invoke()Ljava/lang/Object;
+    .locals 1
+
+    const/4 v0, 0x2
+
+    invoke-virtual {p0, v0}, Lradiant/swipe/ViewAllTrackQueueAction;->invoke(I)Ljava/lang/Object;
+
+    move-result-object v0
 
     return-object v0
 .end method

--- a/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
+++ b/patches/extension/radiant/swipe/ViewAllTrackQueueAction.smali
@@ -40,12 +40,17 @@
 
     iget-wide v1, p0, Lradiant/swipe/ViewAllTrackQueueAction;->trackId:J
 
+    const/4 v3, 0x3
+
+    if-eq p1, v3, :queue_event
+
     invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
 
     move-result v3
 
     if-eqz v3, :play_existing
 
+    :queue_event
     iget-object v3, p0, Lradiant/swipe/ViewAllTrackQueueAction;->context:Landroid/content/Context;
 
     if-eqz v3, :done

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -426,7 +426,8 @@
       "id": "SwipeToQueue",
       "order": 39,
       "fileNames": [
-        "swipe-to-queue.patch"
+        "swipe-to-queue.patch",
+        "swipe-to-queue-compose.patch"
       ],
       "extensionFiles": [
         "radiant/SwipeToQueue.smali",
@@ -442,7 +443,22 @@
         "radiant/swipe/SearchAlbumsResolver.smali",
         "radiant/swipe/SearchPlaylistsResolver.smali",
         "radiant/swipe/PlaylistItemsResolver.smali",
-        "radiant/swipe/UnifiedSearchResolver.smali"
+        "radiant/swipe/UnifiedSearchResolver.smali",
+        "radiant/swipe/ComposeSwipeAction.smali",
+        "radiant/swipe/ComposeSwipeState.smali",
+        "radiant/swipe/ComposeSwipeState$Gesture.smali",
+        "radiant/swipe/ComposeSwipeState$Draw.smali",
+        "radiant/swipe/ComposeSwipeState$ResetAnimator.smali",
+        "radiant/swipe/ComposeTapGuard.smali",
+        "radiant/swipe/AlbumItemQueueAction.smali",
+        "radiant/swipe/DynamicTrackQueueEvent.smali",
+        "radiant/swipe/DynamicTrackQueueAction.smali",
+        "radiant/swipe/DynamicTrackQueue.smali",
+        "radiant/swipe/ViewAllTrackQueueAction.smali",
+        "radiant/swipe/ViewAllTrackQueue.smali",
+        "radiant/swipe/ComposeSearchQueueEvent.smali",
+        "radiant/swipe/ComposeSearchQueueAction.smali",
+        "radiant/swipe/ComposeSearchQueue.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue",

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -430,10 +430,16 @@
       ],
       "extensionFiles": [
         "radiant/SwipeToQueue.smali",
-        "radiant/QueueSwipeRemove.smali"
+        "radiant/QueueSwipeRemove.smali",
+        "radiant/swipe/QueueRequest.smali",
+        "radiant/swipe/QueueRowResolver.smali",
+        "radiant/swipe/QueueExecutor.smali",
+        "radiant/swipe/FavoriteTracksResolver.smali",
+        "radiant/swipe/DynamicTrackResolver.smali",
+        "radiant/swipe/MyAlbumsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "description": "Swipe on tracks/albums to add them to the play queue.",
       "default": false,
       "advancedOptions": [
         {

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -458,7 +458,17 @@
         "radiant/swipe/ViewAllTrackQueue.smali",
         "radiant/swipe/ComposeSearchQueueEvent.smali",
         "radiant/swipe/ComposeSearchQueueAction.smali",
-        "radiant/swipe/ComposeSearchQueue.smali"
+        "radiant/swipe/ComposeSearchQueue.smali",
+        "radiant/swipe/FeedResolver.smali",
+        "radiant/swipe/ArtistTrackCreditsQueueEvent.smali",
+        "radiant/swipe/ArtistTrackCreditsQueueAction.smali",
+        "radiant/swipe/ArtistTrackCreditsQueue.smali",
+        "radiant/swipe/DynamicMediaQueueEvent.smali",
+        "radiant/swipe/CompactGridMediaQueueAction.smali",
+        "radiant/swipe/VerticalMediaQueueAction.smali",
+        "radiant/swipe/PublicPlaylistQueueAction.smali",
+        "radiant/swipe/DynamicMediaQueue.smali",
+        "radiant/swipe/SuggestionsResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue",

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -471,25 +471,27 @@
         "radiant/swipe/SuggestionsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks/albums/playlists to add them to the play queue",
+      "description": "Swipe on tracks/albums/playlists to add them to the play queue (and more actions)",
       "default": false,
       "advancedOptions": [
         {
           "type": "choice",
           "key": "left_action",
           "title": "Left Swipe Action",
-          "description": "Choose the action for a left swipe",
           "entries": [
             "Disabled",
             "Play next",
-            "Add to queue"
+            "Add to queue",
+            "Add to playlist"
           ],
           "values": [
             "0x0",
             "0x1",
-            "0x2"
+            "0x2",
+            "0x3"
           ],
           "defaultIndex": 2,
+          "inline": true,
           "distinctFrom": "right_action",
           "token": "RL_SWIPE_TO_QUEUE_LEFT_ACTION"
         },
@@ -497,18 +499,20 @@
           "type": "choice",
           "key": "right_action",
           "title": "Right Swipe Action",
-          "description": "Choose the action for a right swipe",
           "entries": [
             "Disabled",
             "Play next",
-            "Add to queue"
+            "Add to queue",
+            "Add to playlist"
           ],
           "values": [
             "0x0",
             "0x1",
-            "0x2"
+            "0x2",
+            "0x3"
           ],
           "defaultIndex": 0,
+          "inline": true,
           "distinctFrom": "left_action",
           "token": "RL_SWIPE_TO_QUEUE_RIGHT_ACTION"
         },
@@ -516,11 +520,10 @@
           "type": "choice",
           "key": "remove_direction",
           "title": "Remove Track from Queue",
-          "description": "Choose the swipe direction used to remove items from the play queue",
           "entries": [
             "Left swipe",
             "Right swipe",
-            "Both"
+            "Both directions"
           ],
           "values": [
             "0x4",
@@ -528,6 +531,8 @@
             "0xc"
           ],
           "defaultIndex": 0,
+          "forceDropdown": true,
+          "inline": true,
           "token": "RL_SWIPE_TO_QUEUE_REMOVE_DIRECTION"
         },
         {
@@ -543,6 +548,13 @@
           "title": "Play Next Color",
           "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
+        },
+        {
+          "type": "color",
+          "key": "add_to_playlist_color",
+          "title": "Add to Playlist Color",
+          "default": -14408663,
+          "token": "RL_SWIPE_TO_QUEUE_ADD_TO_PLAYLIST_COLOR"
         }
       ]
     },

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -438,7 +438,11 @@
         "radiant/swipe/DynamicTrackResolver.smali",
         "radiant/swipe/MyAlbumsResolver.smali",
         "radiant/swipe/MyPlaylistsResolver.smali",
-        "radiant/swipe/MyMixesAndRadioResolver.smali"
+        "radiant/swipe/MyMixesAndRadioResolver.smali",
+        "radiant/swipe/SearchAlbumsResolver.smali",
+        "radiant/swipe/SearchPlaylistsResolver.smali",
+        "radiant/swipe/PlaylistItemsResolver.smali",
+        "radiant/swipe/UnifiedSearchResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue",

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -437,7 +437,8 @@
         "radiant/swipe/FavoriteTracksResolver.smali",
         "radiant/swipe/DynamicTrackResolver.smali",
         "radiant/swipe/MyAlbumsResolver.smali",
-        "radiant/swipe/MyPlaylistsResolver.smali"
+        "radiant/swipe/MyPlaylistsResolver.smali",
+        "radiant/swipe/MyMixesAndRadioResolver.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks/albums/playlists to add them to the play queue",

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -476,26 +476,75 @@
       "advancedOptions": [
         {
           "type": "choice",
-          "key": "swipe_direction",
-          "title": "Swipe Direction",
-          "description": "Choose direction of the swipe gesture",
+          "key": "left_action",
+          "title": "Left Swipe Action",
+          "description": "Choose the action for a left swipe",
           "entries": [
-            "Left",
-            "Right"
+            "Disabled",
+            "Play next",
+            "Add to queue"
+          ],
+          "values": [
+            "0x0",
+            "0x1",
+            "0x2"
+          ],
+          "defaultIndex": 2,
+          "distinctFrom": "right_action",
+          "token": "RL_SWIPE_TO_QUEUE_LEFT_ACTION"
+        },
+        {
+          "type": "choice",
+          "key": "right_action",
+          "title": "Right Swipe Action",
+          "description": "Choose the action for a right swipe",
+          "entries": [
+            "Disabled",
+            "Play next",
+            "Add to queue"
+          ],
+          "values": [
+            "0x0",
+            "0x1",
+            "0x2"
+          ],
+          "defaultIndex": 0,
+          "distinctFrom": "left_action",
+          "token": "RL_SWIPE_TO_QUEUE_RIGHT_ACTION"
+        },
+        {
+          "type": "choice",
+          "key": "remove_direction",
+          "title": "Remove Track from Queue",
+          "description": "Choose the swipe direction used to remove items from the play queue",
+          "entries": [
+            "Left swipe",
+            "Right swipe",
+            "Both"
           ],
           "values": [
             "0x4",
-            "0x8"
+            "0x8",
+            "0xc"
           ],
           "defaultIndex": 0,
-          "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+          "token": "RL_SWIPE_TO_QUEUE_REMOVE_DIRECTION"
         },
         {
           "type": "color",
           "key": "background_color",
-          "title": "Background Color",
+          "title": "Add to Queue Color",
+          "default": -14748953,
+          "defaultLabel": "Cyan",
+          "token": "RL_SWIPE_TO_QUEUE_ADD_COLOR"
+        },
+        {
+          "type": "color",
+          "key": "play_next_color",
+          "title": "Play Next Color",
           "default": -14749031,
-          "token": "RL_SWIPE_TO_QUEUE_COLOR"
+          "defaultLabel": "Green",
+          "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
         }
       ]
     },

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -436,10 +436,11 @@
         "radiant/swipe/QueueExecutor.smali",
         "radiant/swipe/FavoriteTracksResolver.smali",
         "radiant/swipe/DynamicTrackResolver.smali",
-        "radiant/swipe/MyAlbumsResolver.smali"
+        "radiant/swipe/MyAlbumsResolver.smali",
+        "radiant/swipe/MyPlaylistsResolver.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe on tracks/albums to add them to the play queue.",
+      "description": "Swipe on tracks/albums/playlists to add them to the play queue",
       "default": false,
       "advancedOptions": [
         {

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -432,8 +432,26 @@
         "radiant/SwipeToQueue.smali"
       ],
       "title": "Swipe to Queue",
-      "description": "Swipe (left only for now) on tracks (in library/my tracks only for now) to add them to the play queue.",
-      "default": false
+      "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "default": false,
+      "advancedOptions": [
+        {
+          "type": "choice",
+          "key": "swipe_direction",
+          "title": "Swipe Direction",
+          "description": "Choose direction of the swipe gesture",
+          "entries": [
+            "Left",
+            "Right"
+          ],
+          "values": [
+            "0x4",
+            "0x8"
+          ],
+          "defaultIndex": 0,
+          "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+        }
+      ]
     },
     {
       "id": "LyricsProgressPill",

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -489,6 +489,13 @@
           ],
           "defaultIndex": 0,
           "token": "RL_SWIPE_TO_QUEUE_DIRECTION"
+        },
+        {
+          "type": "color",
+          "key": "background_color",
+          "title": "Background Color",
+          "default": -14749031,
+          "token": "RL_SWIPE_TO_QUEUE_COLOR"
         }
       ]
     },

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -423,6 +423,19 @@
       "default": false
     },
     {
+      "id": "SwipeToQueue",
+      "order": 39,
+      "fileNames": [
+        "swipe-to-queue.patch"
+      ],
+      "extensionFiles": [
+        "radiant/SwipeToQueue.smali"
+      ],
+      "title": "Swipe to Queue",
+      "description": "Swipe (left only for now) on tracks (in library/my tracks only for now) to add them to the play queue.",
+      "default": false
+    },
+    {
       "id": "LyricsProgressPill",
       "order": 40,
       "fileNames": [

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -534,16 +534,14 @@
           "type": "color",
           "key": "background_color",
           "title": "Add to Queue Color",
-          "default": -14748953,
-          "defaultLabel": "Cyan",
+          "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_ADD_COLOR"
         },
         {
           "type": "color",
           "key": "play_next_color",
           "title": "Play Next Color",
-          "default": -14749031,
-          "defaultLabel": "Green",
+          "default": -14408663,
           "token": "RL_SWIPE_TO_QUEUE_PLAY_NEXT_COLOR"
         }
       ]

--- a/patches/manifest.json
+++ b/patches/manifest.json
@@ -429,7 +429,8 @@
         "swipe-to-queue.patch"
       ],
       "extensionFiles": [
-        "radiant/SwipeToQueue.smali"
+        "radiant/SwipeToQueue.smali",
+        "radiant/QueueSwipeRemove.smali"
       ],
       "title": "Swipe to Queue",
       "description": "Swipe on tracks (in library/my tracks only for now) to add them to the play queue.",

--- a/patches/swipe-to-queue-compose.patch
+++ b/patches/swipe-to-queue-compose.patch
@@ -1,0 +1,253 @@
+--- a/com/tidal/android/dynamicpages/ui/composables/verticaltracklist/j.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/verticaltracklist/j.smali
+@@ -1791,6 +1791,10 @@
+     .line 391
+     check-cast v34, Lam0/a;
+ 
++    invoke-static/range {v34 .. v34}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v34
++
+     .line 392
+     .line 393
+     const/16 v35, 0x6f
+@@ -1832,6 +1836,22 @@
+     .line 412
+     move-result-object v0
+ 
++    iget-wide v14, v3, Lm40/e$e;->a:J
++
++    invoke-static {v14, v15}, Ljava/lang/Long;->valueOf(J)Ljava/lang/Long;
++
++    move-result-object v14
++
++    new-instance v15, Lradiant/swipe/DynamicTrackQueueAction;
++
++    invoke-direct {v15, v4, v1, v2, v3}, Lradiant/swipe/DynamicTrackQueueAction;-><init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$e;)V
++
++    iget-boolean v5, v3, Lm40/e$e;->j:Z
++
++    invoke-static {v0, v14, v15, v5, v11}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v0
++
+     .line 413
+     const/4 v14, 0x0
+ 
+--- a/com/tidal/android/dynamicpages/ui/modules/tracklist/TrackListModuleManager$createModuleViewState$3.smali
++++ b/com/tidal/android/dynamicpages/ui/modules/tracklist/TrackListModuleManager$createModuleViewState$3.smali
+@@ -601,6 +601,17 @@
+ 
+     .line 248
+     :cond_c
++    instance-of p2, p1, Lradiant/swipe/DynamicTrackQueueEvent;
++
++    if-eqz p2, :cond_d
++
++    check-cast p1, Lradiant/swipe/DynamicTrackQueueEvent;
++
++    invoke-static {v0, p1}, Lradiant/swipe/DynamicTrackQueue;->handle(Lcom/tidal/android/dynamicpages/ui/modules/tracklist/TrackListModuleManager;Lradiant/swipe/DynamicTrackQueueEvent;)V
++
++    goto :goto_4
++
++    :cond_d
+     invoke-static {}, Landroidx/navigation/f0;->a()V
+ 
+     .line 249
+--- a/com/tidal/android/feature/search/ui/SearchScreenViewModel.smali
++++ b/com/tidal/android/feature/search/ui/SearchScreenViewModel.smali
+@@ -926,6 +926,17 @@
+ 
+     .line 4
+     .line 5
++    instance-of v2, v1, Lradiant/swipe/ComposeSearchQueueEvent;
++
++    if-eqz v2, :rl_search_queue_continue
++
++    check-cast v1, Lradiant/swipe/ComposeSearchQueueEvent;
++
++    invoke-static {v0, v1}, Lradiant/swipe/ComposeSearchQueue;->handle(Lcom/tidal/android/feature/search/ui/SearchScreenViewModel;Lradiant/swipe/ComposeSearchQueueEvent;)V
++
++    return-void
++
++    :rl_search_queue_continue
+     invoke-virtual {v1}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+ 
+     .line 6
+--- a/com/tidal/android/feature/search/ui/composables/u0.smali
++++ b/com/tidal/android/feature/search/ui/composables/u0.smali
+@@ -243,6 +243,24 @@
+ 
+     check-cast v2, Lam0/a;
+ 
++    invoke-static {v1}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v1
++
++    new-instance v6, Lradiant/swipe/ComposeSearchQueueAction;
++
++    invoke-direct {v6, p3, v0}, Lradiant/swipe/ComposeSearchQueueAction;-><init>(Lam0/l;Lpb0/b;)V
++
++    invoke-virtual {v6}, Lradiant/swipe/ComposeSearchQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v7
++
++    iget-boolean p1, v0, Lpb0/b$a;->f:Z
++
++    invoke-static {v3, v7, v6, p1, v4}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v3
++
+     const/4 v5, 0x0
+ 
+     .line 20
+@@ -467,7 +485,25 @@
+ 
+     const/4 v5, 0x0
+ 
+-    const/4 v2, 0x0
++    invoke-static {v1}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v1
++
++    new-instance v6, Lradiant/swipe/ComposeSearchQueueAction;
++
++    invoke-direct {v6, p3, v0}, Lradiant/swipe/ComposeSearchQueueAction;-><init>(Lam0/l;Lpb0/b;)V
++
++    invoke-virtual {v6}, Lradiant/swipe/ComposeSearchQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v7
++
++    sget-object v2, Landroidx/compose/ui/Modifier;->Companion:Landroidx/compose/ui/Modifier$Companion;
++
++    const/4 p1, 0x1
++
++    invoke-static {v2, v7, v6, p1, v4}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v2
+ 
+     .line 52
+     invoke-static/range {v0 .. v5}, Lob0/w;->a(Lpb0/b$f;Lam0/a;Landroidx/compose/ui/Modifier;Lam0/a;Landroidx/compose/runtime/Composer;I)V
+@@ -593,6 +629,24 @@
+ 
+     check-cast v3, Lam0/a;
+ 
++    invoke-static {v1}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v1
++
++    new-instance v6, Lradiant/swipe/ComposeSearchQueueAction;
++
++    invoke-direct {v6, p3, v0}, Lradiant/swipe/ComposeSearchQueueAction;-><init>(Lam0/l;Lpb0/b;)V
++
++    invoke-virtual {v6}, Lradiant/swipe/ComposeSearchQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v7
++
++    iget-boolean p1, v0, Lpb0/b$i;->i:Z
++
++    invoke-static {v2, v7, v6, p1, v4}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v2
++
+     const/4 v5, 0x0
+ 
+     .line 70
+@@ -828,7 +882,25 @@
+ 
+     const/4 v5, 0x0
+ 
+-    const/4 v2, 0x0
++    invoke-static {v1}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v1
++
++    new-instance v6, Lradiant/swipe/ComposeSearchQueueAction;
++
++    invoke-direct {v6, p3, v0}, Lradiant/swipe/ComposeSearchQueueAction;-><init>(Lam0/l;Lpb0/b;)V
++
++    invoke-virtual {v6}, Lradiant/swipe/ComposeSearchQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v7
++
++    sget-object v2, Landroidx/compose/ui/Modifier;->Companion:Landroidx/compose/ui/Modifier$Companion;
++
++    const/4 p1, 0x1
++
++    invoke-static {v2, v7, v6, p1, v4}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v2
+ 
+     .line 104
+     invoke-static/range {v0 .. v5}, Lob0/q;->a(Lpb0/b$e;Lam0/a;Landroidx/compose/ui/Modifier;Lam0/a;Landroidx/compose/runtime/Composer;I)V
+--- a/com/tidal/android/feature/viewall/ui/l.smali
++++ b/com/tidal/android/feature/viewall/ui/l.smali
+@@ -317,6 +317,31 @@
+     .line 132
+     check-cast v3, Lam0/l;
+ 
++    instance-of p1, v2, Lm40/e$e;
++
++    if-eqz p1, :rl_viewall_swipe_attached
++
++    move-object p1, v2
++
++    check-cast p1, Lm40/e$e;
++
++    iget-wide p2, p1, Lm40/e$e;->a:J
++
++    invoke-static {p2, p3}, Ljava/lang/Long;->valueOf(J)Ljava/lang/Long;
++
++    move-result-object p2
++
++    new-instance p3, Lradiant/swipe/ViewAllTrackQueueAction;
++
++    invoke-direct {p3, v3, p1}, Lradiant/swipe/ViewAllTrackQueueAction;-><init>(Lam0/l;Lm40/e$e;)V
++
++    iget-boolean p1, p1, Lm40/e$e;->j:Z
++
++    invoke-static {v1, p2, p3, p1, v5}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v1
++
++    :rl_viewall_swipe_attached
+     .line 133
+     .line 134
+     const/4 v6, 0x0
+--- a/j40/p2.smali
++++ b/j40/p2.smali
+@@ -3240,5 +3240,14 @@
+     move-object/from16 v16, v1
+ 
++    instance-of v3, v14, Lcom/tidal/android/feature/viewall/ui/n;
++
++    if-eqz v3, :rl_viewall_tap_guard_done
++
++    invoke-static/range {v24 .. v24}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v24
++
++    :rl_viewall_tap_guard_done
+     .line 718
+     .line 719
+     move-object/from16 v25, v9
+--- a/com/tidal/android/feature/viewall/ui/ViewAllScreenViewModel.smali
++++ b/com/tidal/android/feature/viewall/ui/ViewAllScreenViewModel.smali
+@@ -1718,6 +1718,17 @@
+         }
+     .end annotation
+ 
++    invoke-static {p0, p1}, Lradiant/swipe/ViewAllTrackQueue;->handleEvent(Lcom/tidal/android/feature/viewall/ui/ViewAllScreenViewModel;Lcom/tidal/android/feature/viewall/ui/e;)Z
++
++    move-result v0
++
++    if-eqz v0, :rl_viewall_regular_event
++
++    sget-object v0, Lkotlin/u;->a:Lkotlin/u;
++
++    return-object v0
++
++    :rl_viewall_regular_event
+     .line 1
+     instance-of v0, p1, Lcom/tidal/android/feature/viewall/ui/e$a;
+ 

--- a/patches/swipe-to-queue-compose.patch
+++ b/patches/swipe-to-queue-compose.patch
@@ -54,6 +54,84 @@
      invoke-static {}, Landroidx/navigation/f0;->a()V
  
      .line 249
+--- a/com/tidal/android/dynamicpages/ui/composables/compactgridcard/CompactGridCardModuleRowKt.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/compactgridcard/CompactGridCardModuleRowKt.smali
+@@ -872,1 +872,26 @@
++    invoke-static {v10}, Lradiant/swipe/CompactGridMediaQueueAction;->isEligible(Lm40/e;)Z
++
++    move-result v11
++
++    if-eqz v11, :rl_compact_grid_swipe_done
++
++    new-instance v11, Lradiant/swipe/CompactGridMediaQueueAction;
++
++    move-object/from16 v12, p0
++
++    move-object/from16 v14, p1
++
++    invoke-direct {v11, v4, v12, v14, v10}, Lradiant/swipe/CompactGridMediaQueueAction;-><init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e;)V
++
++    invoke-virtual {v11}, Lradiant/swipe/CompactGridMediaQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v12
++
++    const/4 v14, 0x1
++
++    invoke-static {v9, v12, v11, v14, v13}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v9
++
++    :rl_compact_grid_swipe_done
+     const v11, 0xe000
+--- a/com/tidal/android/dynamicpages/ui/composables/compactgridcard/d.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/compactgridcard/d.smali
+@@ -38,1 +38,22 @@
++    instance-of v0, p1, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    if-eqz v0, :rl_compact_grid_native_click
++
++    iget-object v0, p0, Lcom/tidal/android/dynamicpages/ui/composables/compactgridcard/d;->b:Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/c;
++
++    iget-object v1, v0, Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/c;->f:Lam0/q;
++
++    iget-object v2, p0, Lcom/tidal/android/dynamicpages/ui/composables/compactgridcard/d;->c:Ljava/lang/String;
++
++    iget-object v3, v0, Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/c;->a:Ljava/lang/String;
++
++    const/4 v4, 0x0
++
++    invoke-interface {v1, v2, v3, p1, v4}, Lam0/q;->invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
++
++    sget-object p1, Lkotlin/u;->a:Lkotlin/u;
++
++    return-object p1
++
++    :rl_compact_grid_native_click
+     .line 1
+--- a/com/tidal/android/dynamicpages/ui/modules/compactgridcard/CompactGridCardModuleManager$createModuleViewState$2$2.smali
++++ b/com/tidal/android/dynamicpages/ui/modules/compactgridcard/CompactGridCardModuleManager$createModuleViewState$2$2.smali
+@@ -72,1 +72,1 @@
+-    .locals 0
++    .locals 1
+@@ -74,1 +74,18 @@
++    instance-of v0, p3, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    if-eqz v0, :rl_compact_grid_native_event
++
++    iget-object v0, p0, Lkotlin/jvm/internal/AdaptedFunctionReference;->receiver:Ljava/lang/Object;
++
++    check-cast v0, Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/a;
++
++    check-cast p3, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    invoke-static {v0, p3}, Lradiant/swipe/DynamicMediaQueue;->handleCompact(Lcom/tidal/android/dynamicpages/ui/modules/compactgridcard/a;Lradiant/swipe/DynamicMediaQueueEvent;)V
++
++    sget-object p1, Lkotlin/u;->a:Lkotlin/u;
++
++    return-object p1
++
++    :rl_compact_grid_native_event
+     .line 1
 --- a/com/tidal/android/feature/search/ui/SearchScreenViewModel.smali
 +++ b/com/tidal/android/feature/search/ui/SearchScreenViewModel.smali
 @@ -926,6 +926,17 @@
@@ -233,7 +311,7 @@
      move-object/from16 v25, v9
 --- a/com/tidal/android/feature/viewall/ui/ViewAllScreenViewModel.smali
 +++ b/com/tidal/android/feature/viewall/ui/ViewAllScreenViewModel.smali
-@@ -1718,6 +1718,17 @@
+@@ -1717,5 +1717,16 @@
          }
      .end annotation
  
@@ -250,4 +328,153 @@
 +    :rl_viewall_regular_event
      .line 1
      instance-of v0, p1, Lcom/tidal/android/feature/viewall/ui/e$a;
- 
+--- a/com/tidal/android/dynamicpages/ui/composables/artisttrackcredits/h.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/artisttrackcredits/h.smali
+@@ -929,1 +929,5 @@
+     check-cast v34, Lam0/a;
++    invoke-static/range {v34 .. v34}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v34
++
+@@ -970,1 +974,17 @@
+     move-result-object v0
++    iget-wide v14, v3, Lm40/e$e;->a:J
++
++    invoke-static {v14, v15}, Ljava/lang/Long;->valueOf(J)Ljava/lang/Long;
++
++    move-result-object v14
++
++    new-instance v15, Lradiant/swipe/ArtistTrackCreditsQueueAction;
++
++    invoke-direct {v15, v4, v1, v2, v3}, Lradiant/swipe/ArtistTrackCreditsQueueAction;-><init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$e;)V
++
++    iget-boolean v5, v3, Lm40/e$e;->j:Z
++
++    invoke-static {v0, v14, v15, v5, v11}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v0
++
+--- a/com/tidal/android/dynamicpages/ui/modules/artisttrackcredits/ArtistTrackCreditsModuleManager$createModuleViewState$3.smali
++++ b/com/tidal/android/dynamicpages/ui/modules/artisttrackcredits/ArtistTrackCreditsModuleManager$createModuleViewState$3.smali
+@@ -603,1 +603,12 @@
+     :cond_c
++    instance-of p2, p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;
++
++    if-eqz p2, :rl_artist_credits_queue_unhandled
++
++    check-cast p1, Lradiant/swipe/ArtistTrackCreditsQueueEvent;
++
++    invoke-static {v0, p1}, Lradiant/swipe/ArtistTrackCreditsQueue;->handle(Lcom/tidal/android/dynamicpages/ui/modules/artisttrackcredits/ArtistTrackCreditsModuleManager;Lradiant/swipe/ArtistTrackCreditsQueueEvent;)V
++
++    goto :goto_4
++
++    :rl_artist_credits_queue_unhandled
+--- a/com/tidal/android/dynamicpages/ui/composables/verticallistcard/VerticalListCardKt.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/verticallistcard/VerticalListCardKt.smali
+@@ -3648,1 +3648,24 @@
+     move-result-object v0
++    invoke-static {v10}, Lradiant/swipe/VerticalMediaQueueAction;->isSupported(Lm40/e;)Z
++
++    move-result v7
++
++    if-eqz v7, :rl_vertical_swipe_done
++
++    new-instance v7, Lradiant/swipe/VerticalMediaQueueAction;
++
++    invoke-direct {v7, v4, v1, v2, v10}, Lradiant/swipe/VerticalMediaQueueAction;-><init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e;)V
++
++    invoke-virtual {v7}, Lradiant/swipe/VerticalMediaQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v9
++
++    invoke-static {v10}, Lradiant/swipe/VerticalMediaQueueAction;->isEligible(Lm40/e;)Z
++
++    move-result v12
++
++    invoke-static {v0, v9, v7, v12, v3}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v0
++
++    :rl_vertical_swipe_done
+--- a/j40/e4.smali
++++ b/j40/e4.smali
+@@ -310,1 +310,24 @@
+     check-cast v11, Lam0/a;
++    instance-of v8, v6, Lcom/tidal/android/dynamicpages/ui/composables/verticallistcard/m;
++
++    if-eqz v8, :rl_vertical_tap_guard_done
++
++    instance-of v8, v5, Lm40/e;
++
++    if-eqz v8, :rl_vertical_tap_guard_done
++
++    move-object v8, v5
++
++    check-cast v8, Lm40/e;
++
++    invoke-static {v8}, Lradiant/swipe/VerticalMediaQueueAction;->isSupported(Lm40/e;)Z
++
++    move-result v8
++
++    if-eqz v8, :rl_vertical_tap_guard_done
++
++    invoke-static {v11}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v11
++
++    :rl_vertical_tap_guard_done
+--- a/com/tidal/android/dynamicpages/ui/composables/publicplaylistlist/i.smali
++++ b/com/tidal/android/dynamicpages/ui/composables/publicplaylistlist/i.smali
+@@ -2120,1 +2120,5 @@
+     check-cast v34, Lam0/a;
++    invoke-static/range {v34 .. v34}, Lradiant/swipe/ComposeTapGuard;->wrap(Lam0/a;)Lam0/a;
++
++    move-result-object v34
++
+@@ -2161,1 +2165,15 @@
+     move-result-object v0
++    new-instance v5, Lradiant/swipe/PublicPlaylistQueueAction;
++
++    invoke-direct {v5, v4, v1, v2, v3}, Lradiant/swipe/PublicPlaylistQueueAction;-><init>(Lam0/l;Ljava/lang/String;Ljava/lang/String;Lm40/e$d;)V
++
++    invoke-virtual {v5}, Lradiant/swipe/PublicPlaylistQueueAction;->stableKey()Ljava/lang/String;
++
++    move-result-object v7
++
++    iget-boolean v9, v3, Lm40/e$d;->g:Z
++
++    invoke-static {v0, v7, v5, v9, v11}, Lradiant/swipe/ComposeSwipeState;->attach(Landroidx/compose/ui/Modifier;Ljava/lang/Object;Lradiant/swipe/ComposeSwipeAction;ZLandroidx/compose/runtime/Composer;)Landroidx/compose/ui/Modifier;
++
++    move-result-object v0
++
+--- a/com/tidal/android/dynamicpages/ui/modules/verticallistcard/VerticalListCardModuleManager$createModuleViewState$3.smali
++++ b/com/tidal/android/dynamicpages/ui/modules/verticallistcard/VerticalListCardModuleManager$createModuleViewState$3.smali
+@@ -830,1 +830,12 @@
+     :cond_15
++    instance-of v2, v0, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    if-eqz v2, :rl_vertical_queue_continue
++
++    check-cast v0, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    invoke-static {v3, v0}, Lradiant/swipe/DynamicMediaQueue;->handleVertical(Lcom/tidal/android/dynamicpages/ui/modules/verticallistcard/VerticalListCardModuleManager;Lradiant/swipe/DynamicMediaQueueEvent;)V
++
++    goto :goto_2
++
++    :rl_vertical_queue_continue
+--- a/com/tidal/android/dynamicpages/ui/modules/publicplaylistlist/PublicPlaylistListModuleManager$createModuleViewState$3.smali
++++ b/com/tidal/android/dynamicpages/ui/modules/publicplaylistlist/PublicPlaylistListModuleManager$createModuleViewState$3.smali
+@@ -487,2 +487,13 @@
+     :cond_c
++    instance-of v1, p1, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    if-eqz v1, :rl_public_queue_continue
++
++    check-cast p1, Lradiant/swipe/DynamicMediaQueueEvent;
++
++    invoke-static {p2, p1}, Lradiant/swipe/DynamicMediaQueue;->handlePublicPlaylist(Lcom/tidal/android/dynamicpages/ui/modules/publicplaylistlist/PublicPlaylistListModuleManager;Lradiant/swipe/DynamicMediaQueueEvent;)V
++
++    goto :goto_1
++
++    :rl_public_queue_continue
+     invoke-static {}, Landroidx/navigation/f0;->a()V

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,0 +1,157 @@
+--- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
++++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
+@@ -107,6 +107,104 @@
+ .end method
+ 
+ 
++.method public final Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
++    .locals 3
++
++    # reject unavailable tracks
++    if-eqz p2, :not_eligible
++
++    iget-object v0, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->d:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;
++
++    if-eqz v0, :not_eligible
++
++    invoke-virtual {v0, p1}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;->b(I)Lcom/aspiro/wamp/model/FavoriteTrack;
++
++    move-result-object v1
++
++    if-eqz v1, :not_eligible
++
++    invoke-virtual {p2}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
++
++    move-result v2
++
++    invoke-virtual {v1}, Lcom/aspiro/wamp/model/MediaItem;->getId()I
++
++    move-result p1
++
++    if-ne v2, p1, :not_eligible
++
++    iget-object v0, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->f:Lcom/aspiro/wamp/model/AvailabilityInteractor;
++
++    if-eqz v0, :not_eligible
++
++    invoke-interface {v0, v1}, Lcom/aspiro/wamp/model/AvailabilityInteractor;->getAvailability(Lcom/aspiro/wamp/model/MediaItem;)Lcom/aspiro/wamp/model/Availability$MediaItem;
++
++    move-result-object v0
++
++    invoke-virtual {v0}, Lcom/aspiro/wamp/model/Availability$MediaItem;->isAvailable()Z
++
++    move-result v0
++
++    if-eqz v0, :not_eligible
++
++    const/4 v0, 0x1
++
++    return v0
++
++    :not_eligible
++    const/4 v0, 0x0
++
++    return v0
++.end method
++
++.method public final Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
++    .locals 5
++
++    invoke-virtual {p0, p1, p2}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
++
++    move-result p1
++
++    if-eqz p1, :done
++
++    # accepts a Source, wrap the swiped track.
++    iget-object p1, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->d:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;
++
++    if-eqz p1, :done
++
++    iget-object v0, p1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;->m:Lcom/tidal/android/navigation/NavigationInfo;
++
++    invoke-static {v0}, Lcom/aspiro/wamp/playqueue/source/model/b;->m(Lcom/tidal/android/navigation/NavigationInfo;)Lcom/aspiro/wamp/playqueue/source/model/MyItemsSource;
++
++    move-result-object v4
++
++    invoke-virtual {v4, p2}, Lcom/aspiro/wamp/playqueue/source/model/Source;->addSourceItem(Lcom/aspiro/wamp/model/MediaItem;)V
++
++    iget-object v3, p1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;->k:Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;
++
++    iget-object v0, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->b:Lx40/a;
++
++    instance-of p1, v0, Lh4/a;
++
++    if-eqz p1, :done
++
++    check-cast v0, Lh4/a;
++
++    invoke-virtual {p0}, Landroidx/fragment/app/Fragment;->getActivity()Landroidx/fragment/app/FragmentActivity;
++
++    move-result-object v1
++
++    if-eqz v1, :done
++
++    move-object v2, p2
++
++    invoke-virtual/range {v0 .. v4}, Lh4/a;->q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
++
++    :done
++    return-void
++.end method
++
++
+ # virtual methods
+ .method public final M()Ln8/b;
+     .locals 1
+@@ -2265,9 +2418,16 @@
+     iput-object p0, p1, Lo4/g;->e:Lo4/g$e;
+
+     .line 224
+     .line 225
+     iput p2, p1, Lo4/g;->b:I
++    iget-object p1, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->l:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/m;
++
++    invoke-virtual {p1}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
++
++    iget-object p1, p1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/m;->f:Landroidx/recyclerview/widget/RecyclerView;
++
++    invoke-static {p0, p1}, Lradiant/SwipeToQueue;->install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
+
+     .line 226
+     .line 227
+     invoke-virtual {p0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->N()Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/n;
+--- a/h4/a.smali
++++ b/h4/a.smali
+@@ -931,3 +931,32 @@
+ .end method
++
++.method public final q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
++    .locals 2
++
++    iget-object v0, p0, Lh4/a;->n:Lcom/aspiro/wamp/contextmenu/menu/track/TrackContextMenu$a;
++
++    check-cast v0, Lcom/aspiro/wamp/contextmenu/menu/track/d;
++
++    iget-object v0, v0, Lcom/aspiro/wamp/contextmenu/menu/track/d;->a:Lcom/aspiro/wamp/contextmenu/menu/track/c;
++
++    iget-object v0, v0, Lcom/aspiro/wamp/contextmenu/menu/track/c;->b:Ldagger/internal/j;
++
++    invoke-interface {v0}, Lql0/a;->get()Ljava/lang/Object;
++
++    move-result-object v0
++
++    check-cast v0, Lm3/f$a;
++
++    invoke-interface {v0, p2, p3, p4}, Lm3/f$a;->a(Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Lm3/f;
++
++    move-result-object v0
++
++    # call add to queue method
++    invoke-virtual {v0, p1}, Lm3/f;->b(Landroidx/fragment/app/FragmentActivity;)V
++
++    return-void
++.end method
++
+ 
+ .method public final o(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Credit;Lcom/tidal/android/navigation/NavigationInfo;)V

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -2,7 +2,7 @@
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 @@ -107,6 +107,118 @@
  .end method
- 
+
  
 +.method public final Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
 +    .locals 3
@@ -131,11 +131,61 @@
 +
 +    iget-object p1, p1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/m;->f:Landroidx/recyclerview/widget/RecyclerView;
 +
-+    invoke-static {p0, p1}, Lradiant/SwipeToQueue;->install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
++    invoke-static {p0, p1}, Lradiant/swipe/FavoriteTracksResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;Landroidx/recyclerview/widget/RecyclerView;)V
 
      .line 226
      .line 227
      invoke-virtual {p0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->N()Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/n;
+--- a/p7/a.smali
++++ b/p7/a.smali
+@@ -33,3 +33,11 @@
+ .end method
+
++.method public b(Landroidx/recyclerview/widget/RecyclerView;)V
++    .locals 0
++
++    invoke-static {p1}, Lradiant/swipe/DynamicTrackResolver;->install(Landroidx/recyclerview/widget/RecyclerView;)V
++
++    return-void
++.end method
++
+ .method public final c(Ljava/lang/Object;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)V
+--- a/com/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView.smali
++++ b/com/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView.smali
+@@ -1286,6 +1286,8 @@
+     .line 23
+     invoke-static {v0, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/MyAlbumsResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 24
+     .line 25
+     .line 26
+--- a/androidx/recyclerview/widget/ItemTouchHelper$2.smali
++++ b/androidx/recyclerview/widget/ItemTouchHelper$2.smali
+@@ -773,7 +773,11 @@
+     const/4 v5, 0x1
+
+     .line 54
+-    if-eq p1, v5, :cond_9
++    if-ne p1, v5, :rl_not_explicit_release
++    iget-object v6, v2, Landroidx/recyclerview/widget/ItemTouchHelper;->mCallback:Landroidx/recyclerview/widget/ItemTouchHelper$Callback;
++    invoke-static {v6, v5}, Lradiant/SwipeToQueue;->setReleaseAllowed(Landroidx/recyclerview/widget/ItemTouchHelper$Callback;Z)V
++    goto :cond_9
++    :rl_not_explicit_release
+
+     .line 55
+     .line 56
+@@ -867,6 +871,9 @@
+
+     .line 97
+     :cond_6
++    const/4 v6, 0x0
++    iget-object v1, v2, Landroidx/recyclerview/widget/ItemTouchHelper;->mCallback:Landroidx/recyclerview/widget/ItemTouchHelper$Callback;
++    invoke-static {v1, v6}, Lradiant/SwipeToQueue;->setReleaseAllowed(Landroidx/recyclerview/widget/ItemTouchHelper$Callback;Z)V
+     iget-object p1, v2, Landroidx/recyclerview/widget/ItemTouchHelper;->mVelocityTracker:Landroid/view/VelocityTracker;
+
+     .line 98
 --- a/h4/a.smali
 +++ b/h4/a.smali
 @@ -931,1 +931,46 @@

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,6 +1,6 @@
 --- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
-@@ -107,6 +107,124 @@
+@@ -107,6 +107,143 @@
  .end method
 
  
@@ -54,7 +54,7 @@
 +    return v0
 +.end method
 +
-+.method public final Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
++.method public final Z(ILcom/aspiro/wamp/model/FavoriteTrack;I)V
 +    .locals 6
 +
 +    move v5, p1
@@ -102,9 +102,28 @@
 +
 +    move-object v2, p2
 +
++    const/4 p1, 0x1
++
++    if-ne p3, p1, :rl_favorite_append
++
++    invoke-static {}, Lradiant/swipe/QueueExecutor;->hasActiveQueue()Z
++    move-result p1
++    if-nez p1, :rl_favorite_play_next
++    const/4 v0, 0x0
++    goto :rl_favorite_result
++    :rl_favorite_play_next
++    invoke-static {v1, v2, v3, v4}, Lradiant/swipe/QueueExecutor;->playNextTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
++
++    move-result v0
++
++    goto :rl_favorite_result
++
++    :rl_favorite_append
 +    invoke-virtual/range {v0 .. v4}, Lh4/a;->q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 +
 +    move-result v0
++
++    :rl_favorite_result
 +
 +    if-nez v0, :done
 +
@@ -125,7 +144,7 @@
  # virtual methods
  .method public final M()Ln8/b;
      .locals 1
-@@ -2265,9 +2418,16 @@
+@@ -2265,9 +2437,16 @@
      iput-object p0, p1, Lo4/g;->e:Lo4/g$e;
 
      .line 224
@@ -334,7 +353,7 @@
      .line 32
      .line 33
 -    const/4 v1, 0x4
-+    const/16 v1, __RL_SWIPE_TO_QUEUE_DIRECTION__
++    const/16 v1, __RL_SWIPE_TO_QUEUE_REMOVE_DIRECTION__
  
      .line 34
      :cond_1
@@ -393,7 +412,7 @@
  
 --- a/com/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView.smali
-@@ -1176,6 +1176,8 @@
+@@ -1176,8 +1176,10 @@
      .line 69
      .line 70
      .line 71
@@ -406,7 +425,7 @@
      .line 74
 --- a/com/aspiro/wamp/playlist/ui/fragment/PlaylistFragment.smali
 +++ b/com/aspiro/wamp/playlist/ui/fragment/PlaylistFragment.smali
-@@ -5193,6 +5193,8 @@
+@@ -5193,8 +5193,10 @@
      .line 127
      .line 128
      .line 129
@@ -419,7 +438,7 @@
      .line 132
 --- a/com/aspiro/wamp/search/v2/UnifiedSearchView.smali
 +++ b/com/aspiro/wamp/search/v2/UnifiedSearchView.smali
-@@ -1596,6 +1596,8 @@
+@@ -1596,8 +1596,10 @@
      .line 60
      .line 61
      .line 62
@@ -432,7 +451,7 @@
      .line 65
 --- a/com/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView.smali
-@@ -1204,6 +1204,8 @@
+@@ -1204,8 +1204,10 @@
      .line 69
      .line 70
      .line 71
@@ -458,7 +477,7 @@
      .line 41
 --- a/com/aspiro/wamp/nowplaying/view/suggestions/o0.smali
 +++ b/com/aspiro/wamp/nowplaying/view/suggestions/o0.smali
-@@ -876,8 +876,10 @@
+@@ -876,7 +876,9 @@
      .line 96
      invoke-virtual {v0, p2}, Landroidx/recyclerview/widget/RecyclerView;->setAdapter(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V
 

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,6 +1,6 @@
 --- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
-@@ -107,6 +107,103 @@
+@@ -107,6 +107,118 @@
  .end method
  
  
@@ -55,13 +55,15 @@
 +.end method
 +
 +.method public final Z(ILcom/aspiro/wamp/model/FavoriteTrack;)V
-+    .locals 5
++    .locals 6
++
++    move v5, p1
 +
 +    invoke-virtual {p0, p1, p2}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->Y(ILcom/aspiro/wamp/model/FavoriteTrack;)Z
 +
-+    move-result p1
++    move-result v0
 +
-+    if-eqz p1, :done
++    if-eqz v0, :done
 +
 +    # accepts a Source, wrap the swiped track.
 +    iget-object p1, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->d:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;
@@ -94,7 +96,20 @@
 +
 +    move-object v2, p2
 +
-+    invoke-virtual/range {v0 .. v4}, Lh4/a;->q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
++    invoke-virtual/range {v0 .. v4}, Lh4/a;->q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
++
++    move-result v0
++
++    if-nez v0, :done
++
++    # if nothing is playing, call row click handler to play the track directly instead of adding it to queue
++    iget-object v0, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->l:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/m;
++
++    if-eqz v0, :done
++
++    iget-object v0, v0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/m;->f:Landroidx/recyclerview/widget/RecyclerView;
++
++    invoke-virtual {p0, v0, v5, v0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->w(Landroidx/recyclerview/widget/RecyclerView;ILandroid/view/View;)V
 +
 +    :done
 +    return-void
@@ -123,19 +138,19 @@
      invoke-virtual {p0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->N()Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/n;
 --- a/h4/a.smali
 +++ b/h4/a.smali
-@@ -931,3 +931,31 @@
+@@ -931,3 +931,49 @@
  .end method
 +
-+.method public final q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
-+    .locals 2
++.method public final q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
++    .locals 3
 +
 +    iget-object v0, p0, Lh4/a;->n:Lcom/aspiro/wamp/contextmenu/menu/track/TrackContextMenu$a;
 +
 +    check-cast v0, Lcom/aspiro/wamp/contextmenu/menu/track/d;
 +
-+    iget-object v0, v0, Lcom/aspiro/wamp/contextmenu/menu/track/d;->a:Lcom/aspiro/wamp/contextmenu/menu/track/c;
++    iget-object v1, v0, Lcom/aspiro/wamp/contextmenu/menu/track/d;->a:Lcom/aspiro/wamp/contextmenu/menu/track/c;
 +
-+    iget-object v0, v0, Lcom/aspiro/wamp/contextmenu/menu/track/c;->b:Ldagger/internal/j;
++    iget-object v0, v1, Lcom/aspiro/wamp/contextmenu/menu/track/c;->b:Ldagger/internal/j;
 +
 +    invoke-interface {v0}, Lql0/a;->get()Ljava/lang/Object;
 +
@@ -147,10 +162,28 @@
 +
 +    move-result-object v0
 +
-+    # call add to queue method
++    iget-object v2, v0, Lm3/f;->j:Lcom/aspiro/wamp/playqueue/g1;
++
++    invoke-virtual {v2}, Lcom/aspiro/wamp/playqueue/g1;->a()Lcom/aspiro/wamp/player/d;
++
++    move-result-object v2
++
++    invoke-virtual {v2}, Lcom/aspiro/wamp/player/d;->b()Lcom/aspiro/wamp/model/MediaItemParent;
++
++    move-result-object v2
++
++    if-eqz v2, :empty_queue
++
 +    invoke-virtual {v0, p1}, Lm3/f;->b(Landroidx/fragment/app/FragmentActivity;)V
 +
-+    return-void
++    const/4 v0, 0x1
++
++    return v0
++
++    :empty_queue
++    const/4 v0, 0x0
++
++    return v0
 +.end method
 +
  

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -146,7 +146,21 @@
 +++ b/p7/a.smali
 @@ -33,3 +33,11 @@
  .end method
-
+ 
++.method public b(Landroidx/recyclerview/widget/RecyclerView;)V
++    .locals 0
++
++    invoke-static {p1}, Lradiant/swipe/DynamicTrackResolver;->install(Landroidx/recyclerview/widget/RecyclerView;)V
++
++    return-void
++.end method
++
+ .method public final c(Ljava/lang/Object;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)V
+--- a/v6/e.smali
++++ b/v6/e.smali
+@@ -62,3 +62,11 @@
+ .end method
+ 
 +.method public b(Landroidx/recyclerview/widget/RecyclerView;)V
 +    .locals 0
 +

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,6 +1,6 @@
 --- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
-@@ -107,6 +107,118 @@
+@@ -107,6 +107,124 @@
  .end method
 
  
@@ -69,6 +69,12 @@
 +    iget-object p1, p0, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->d:Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;
 +
 +    if-eqz p1, :done
++
++    invoke-virtual {p1, v5}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;->b(I)Lcom/aspiro/wamp/model/FavoriteTrack;
++
++    move-result-object p2
++
++    if-eqz p2, :done
 +
 +    iget-object v0, p1, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/g0;->m:Lcom/tidal/android/navigation/NavigationInfo;
 +

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,6 +1,6 @@
 --- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
-@@ -107,6 +107,143 @@
+@@ -107,6 +107,154 @@
  .end method
 
  
@@ -102,6 +102,10 @@
 +
 +    move-object v2, p2
 +
++    const/4 p1, 0x3
++
++    if-eq p3, p1, :rl_favorite_add_to_playlist
++
 +    const/4 p1, 0x1
 +
 +    if-ne p3, p1, :rl_favorite_append
@@ -122,6 +126,13 @@
 +    invoke-virtual/range {v0 .. v4}, Lh4/a;->q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
 +
 +    move-result v0
++
++    goto :rl_favorite_result
++
++    :rl_favorite_add_to_playlist
++    invoke-static {v1, v2, v3, v4}, Lradiant/swipe/QueueExecutor;->addToPlaylistTrack(Landroid/content/Context;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V
++
++    goto :done
 +
 +    :rl_favorite_result
 +
@@ -144,7 +155,7 @@
  # virtual methods
  .method public final M()Ln8/b;
      .locals 1
-@@ -2265,9 +2437,16 @@
+@@ -2265,9 +2448,16 @@
      iput-object p0, p1, Lo4/g;->e:Lo4/g$e;
 
      .line 224

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -152,7 +152,7 @@
  .method public final c(Ljava/lang/Object;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)V
 --- a/com/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/albums/myalbums/MyAlbumsView.smali
-@@ -1286,6 +1286,8 @@
+@@ -559,6 +559,8 @@
      .line 23
      invoke-static {v0, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
 
@@ -163,11 +163,23 @@
      .line 26
 --- a/com/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView.smali
-@@ -1297,6 +1297,8 @@
+@@ -581,6 +581,8 @@
      .line 23
      invoke-static {p1, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
 
 +    invoke-static {p0, p2}, Lradiant/swipe/MyPlaylistsResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 24
+     .line 25
+     .line 26
+--- a/com/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView.smali
++++ b/com/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView.smali
+@@ -556,6 +556,8 @@
+     .line 22
+     .line 23
+     invoke-static {p1, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/MyMixesAndRadioResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/mixesandradios/MyMixesAndRadioView;Landroidx/recyclerview/widget/RecyclerView;)V
 +
      .line 24
      .line 25

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -161,6 +161,17 @@
      .line 24
      .line 25
      .line 26
+--- a/com/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView.smali
++++ b/com/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView.smali
+@@ -1297,6 +1297,8 @@
+     .line 23
+     invoke-static {p1, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/MyPlaylistsResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/playlists/myplaylists/MyPlaylistsView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 24
+     .line 25
+     .line 26
 --- a/androidx/recyclerview/widget/ItemTouchHelper$2.smali
 +++ b/androidx/recyclerview/widget/ItemTouchHelper$2.smali
 @@ -773,7 +773,11 @@

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -1,6 +1,6 @@
 --- a/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
 +++ b/com/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment.smali
-@@ -107,6 +107,104 @@
+@@ -107,6 +107,103 @@
  .end method
  
  
@@ -123,7 +123,7 @@
      invoke-virtual {p0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->N()Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/n;
 --- a/h4/a.smali
 +++ b/h4/a.smali
-@@ -931,3 +931,32 @@
+@@ -931,3 +931,31 @@
  .end method
 +
 +.method public final q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)V

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -443,3 +443,34 @@
      .line 72
      .line 73
      .line 74
+--- a/com/tidal/android/feature/feed/ui/FeedView.smali
++++ b/com/tidal/android/feature/feed/ui/FeedView.smali
+@@ -306,8 +306,10 @@
+     .line 36
+     .line 37
+     .line 38
+     invoke-static {p2, p1}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p1}, Lradiant/swipe/FeedResolver;->install(Lcom/tidal/android/feature/feed/ui/FeedView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 39
+     .line 40
+     .line 41
+--- a/com/aspiro/wamp/nowplaying/view/suggestions/o0.smali
++++ b/com/aspiro/wamp/nowplaying/view/suggestions/o0.smali
+@@ -876,8 +876,10 @@
+     .line 96
+     invoke-virtual {v0, p2}, Landroidx/recyclerview/widget/RecyclerView;->setAdapter(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V
+
++    invoke-static {p0, v0}, Lradiant/swipe/SuggestionsResolver;->install(Landroidx/fragment/app/Fragment;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 97
+     .line 98
+     .line 99
+     invoke-virtual {p0}, Lcom/aspiro/wamp/nowplaying/view/suggestions/o0;->M()Lcom/aspiro/wamp/nowplaying/view/suggestions/l;
+--- a/com/aspiro/wamp/nowplaying/view/suggestions/h.smali
++++ b/com/aspiro/wamp/nowplaying/view/suggestions/h.smali
+@@ -674,1 +674,3 @@
+     invoke-virtual {v3, p2}, Landroidx/recyclerview/widget/RecyclerView;->setAdapter(Landroidx/recyclerview/widget/RecyclerView$Adapter;)V
++    invoke-static {p0, v3}, Lradiant/swipe/SuggestionsResolver;->install(Landroidx/fragment/app/Fragment;Landroidx/recyclerview/widget/RecyclerView;)V
++

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -138,7 +138,7 @@
      invoke-virtual {p0}, Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/FavoriteTracksFragment;->N()Lcom/aspiro/wamp/mycollection/subpages/favoritetracks/n;
 --- a/h4/a.smali
 +++ b/h4/a.smali
-@@ -931,3 +931,49 @@
+@@ -931,1 +931,46 @@
  .end method
 +
 +.method public final q(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Track;Lcom/aspiro/wamp/eventtracking/model/ContextualMetadata;Lcom/aspiro/wamp/playqueue/source/model/Source;)Z
@@ -185,6 +185,116 @@
 +
 +    return v0
 +.end method
+--- a/com/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl.smali
++++ b/com/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl.smali
+@@ -31,6 +31,10 @@
+ 
+ .field public g:I
+ 
++.field public final h:Landroid/graphics/drawable/Drawable;
++
++.field public i:Z
 +
  
- .method public final o(Landroidx/fragment/app/FragmentActivity;Lcom/aspiro/wamp/model/Credit;Lcom/tidal/android/navigation/NavigationInfo;)V
+ # direct methods
+ .method public constructor <init>(Landroid/content/Context;Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/a;Lcom/aspiro/wamp/nowplaying/view/playqueue/l;)V
+@@ -55,6 +59,26 @@
+ 
+     .line 10
+     .line 11
++    # trash icon
++    sget p2, Lcom/aspiro/wamp/R$drawable;->ic_delete:I
++
++    invoke-virtual {p1, p2}, Landroid/content/Context;->getDrawable(I)Landroid/graphics/drawable/Drawable;
++
++    move-result-object p2
++
++    if-eqz p2, :store_remove_icon
++
++    invoke-virtual {p2}, Landroid/graphics/drawable/Drawable;->mutate()Landroid/graphics/drawable/Drawable;
++
++    move-result-object p2
++
++    const/4 p3, -0x1
++
++    invoke-virtual {p2, p3}, Landroid/graphics/drawable/Drawable;->setTint(I)V
++
++    :store_remove_icon
++    iput-object p2, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->h:Landroid/graphics/drawable/Drawable;
++
+     new-instance p2, Landroid/graphics/drawable/ColorDrawable;
+ 
+     .line 12
+@@ -377,6 +401,10 @@
+     .line 5
+     .line 6
+     .line 7
++    const/4 v0, 0x0
++
++    iput-boolean v0, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->i:Z
++
+     iget-object v0, p0, Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;->d:Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl$ActionType;
+ 
+     .line 8
+@@ -844,7 +872,7 @@
+ 
+     .line 32
+     .line 33
+-    const/4 v1, 0x4
++    const/16 v1, __RL_SWIPE_TO_QUEUE_DIRECTION__
+ 
+     .line 34
+     :cond_1
+@@ -896,7 +924,23 @@
+ .end method
+ 
++.method public getSwipeEscapeVelocity(F)F
++    .locals 1
++    # Float.MAX_VALUE
++    const v0, 0x7f7fffff
++
++    return v0
++.end method
++
++.method public getSwipeThreshold(Landroidx/recyclerview/widget/RecyclerView$ViewHolder;)F
++    .locals 1
++    # 0.3f
++    const v0, 0x3e99999a
++
++    return v0
++.end method
++
+ .method public final onChildDraw(Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FFIZ)V
+-    .locals 2
++    .locals 8
+ 
+     .line 1
+     invoke-virtual {p1}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+@@ -916,6 +960,16 @@
+     .line 10
+     invoke-super/range {p0 .. p7}, Landroidx/recyclerview/widget/ItemTouchHelper$Callback;->onChildDraw(Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FFIZ)V
+ 
++    move-object/from16 v0, p0
++    move-object/from16 v1, p1
++    move-object/from16 v2, p3
++    move/from16 v3, p4
++    move/from16 v4, p6
++    move/from16 v5, p7
++    invoke-static/range {v0 .. v5}, Lradiant/QueueSwipeRemove;->draw(Lcom/aspiro/wamp/nowplaying/view/playqueue/touchmanagement/ItemTouchHelperCallbackImpl;Landroid/graphics/Canvas;Landroidx/recyclerview/widget/RecyclerView$ViewHolder;FIZ)V
++
++    goto :cond_0
++
+     .line 11
+     .line 12
+     .line 13
+--- a/com/aspiro/wamp/nowplaying/view/playqueue/l.smali
++++ b/com/aspiro/wamp/nowplaying/view/playqueue/l.smali
+@@ -983,6 +983,8 @@
+     .line 121
+     move-result-object p1
+ 
++    invoke-static {p1}, Lradiant/QueueSwipeRemove;->setRemoveDuration(Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 122
+     new-instance p2, Landroidx/recyclerview/widget/LinearLayoutManager;
+ 

--- a/patches/swipe-to-queue.patch
+++ b/patches/swipe-to-queue.patch
@@ -377,3 +377,55 @@
      .line 122
      new-instance p2, Landroidx/recyclerview/widget/LinearLayoutManager;
  
+--- a/com/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView.smali
++++ b/com/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView.smali
+@@ -1176,6 +1176,8 @@
+     .line 69
+     .line 70
+     .line 71
+     invoke-static {v0, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/SearchAlbumsResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/albums/search/SearchAlbumsView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 72
+     .line 73
+     .line 74
+--- a/com/aspiro/wamp/playlist/ui/fragment/PlaylistFragment.smali
++++ b/com/aspiro/wamp/playlist/ui/fragment/PlaylistFragment.smali
+@@ -5193,6 +5193,8 @@
+     .line 127
+     .line 128
+     .line 129
+     invoke-static {v1, p1}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p1}, Lradiant/swipe/PlaylistItemsResolver;->install(Lcom/aspiro/wamp/playlist/ui/items/PlaylistItemCollectionView;)V
++
+     .line 130
+     .line 131
+     .line 132
+--- a/com/aspiro/wamp/search/v2/UnifiedSearchView.smali
++++ b/com/aspiro/wamp/search/v2/UnifiedSearchView.smali
+@@ -1596,6 +1596,8 @@
+     .line 60
+     .line 61
+     .line 62
+     invoke-static {v0, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/UnifiedSearchResolver;->install(Lcom/aspiro/wamp/search/v2/UnifiedSearchView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 63
+     .line 64
+     .line 65
+--- a/com/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView.smali
++++ b/com/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView.smali
+@@ -1204,6 +1204,8 @@
+     .line 69
+     .line 70
+     .line 71
+     invoke-static {v0, p2}, Lcom/tidal/android/feature/appscaffold/ui/recyclerview/b;->a(Landroidx/lifecycle/LifecycleOwner;Landroidx/recyclerview/widget/RecyclerView;)Lcom/tidal/android/feature/appscaffold/ui/recyclerview/a;
+
++    invoke-static {p0, p2}, Lradiant/swipe/SearchPlaylistsResolver;->install(Lcom/aspiro/wamp/mycollection/subpages/playlists/searchplaylists/SearchPlaylistsView;Landroidx/recyclerview/widget/RecyclerView;)V
++
+     .line 72
+     .line 73
+     .line 74


### PR DESCRIPTION
#62 

Added Swipe to Queue patch allowing to configure actions on media items swipe gestures :
- Add to queue
- Play next
- Add to playlist

-> Implemented across the app legacy and compose screens, including Home, Search (both legacy and compose rewrite), Library, Albums, Playlists, Mixes, Radios, Suggestions, Updates, Artists, various lists...